### PR TITLE
Feature: add external database support

### DIFF
--- a/charts/librenms/README.gotmpl
+++ b/charts/librenms/README.gotmpl
@@ -24,6 +24,66 @@ $ helm repo add librenms https://www.librenms.org/helm-charts
 $ helm install my-release librenms/librenms
 ```
 
+## Database Configuration
+
+### Internal Database (Default)
+
+By default, the chart deploys MySQL as part of the release (`mysql.enabled: true`).
+No additional database configuration is needed.
+
+### External Database
+
+To use an external MySQL or MariaDB database, disable the bundled MySQL subchart and configure `externalDatabase`:
+
+```yaml
+mysql:
+  enabled: false
+
+externalDatabase:
+  host: mysql.example.com:3306      # hostname:port (port is optional, defaults to 3306)
+  port: 3306                         # (optional if included in host)
+  name: librenms
+  user: librenms
+  password: "your-password"          # or use existingSecret
+  # existingSecret:
+  #   name: my-db-secret             # reference to existing K8s secret
+  #   key: mysql-password            # key in the secret containing the password
+  timeout: 60                        # database connection timeout in seconds
+```
+
+**Note:** You can specify the port in either the `host` field (`mysql.example.com:3306`) OR the `port` field, but not both required.
+
+**Example with existing Kubernetes secret:**
+
+```bash
+# Create a secret with the database password
+kubectl create secret generic db-credentials \
+  --from-literal=mysql-password=your-password \
+  -n default
+```
+
+Then in your values:
+
+```yaml
+mysql:
+  enabled: false
+
+externalDatabase:
+  host: mysql.example.com
+  name: librenms
+  user: librenms
+  existingSecret:
+    name: db-credentials           # K8s secret name
+    key: mysql-password            # key in the secret
+  timeout: 60
+```
+
+**Pre-requisites for external database:**
+- MySQL 5.7+ or MariaDB 10.2+
+- Database user with CREATE, ALTER, DROP, INSERT, UPDATE, DELETE privileges
+- Network connectivity from cluster to database host
+- Pre-created database (ensure `CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`)
+
 ## Persistence
 
 RRDCached uses persistent storage for time-series database files. Two separate PersistentVolumeClaims are configured:

--- a/charts/librenms/templates/_helpers.tpl
+++ b/charts/librenms/templates/_helpers.tpl
@@ -75,3 +75,112 @@ Create the name of the secret to use
 {{- .Release.Name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Database host - returns the database host based on mode (without port)
+*/}}
+{{- define "librenms.dbHost" -}}
+{{- if not .Values.mysql.enabled -}}
+{{- $host := required "externalDatabase.host is required when mysql.enabled is false" .Values.externalDatabase.host -}}
+{{- if contains ":" $host -}}
+{{- $host | splitList ":" | first -}}
+{{- else -}}
+{{- $host -}}
+{{- end -}}
+{{- else -}}
+{{- printf "%s-mysql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database port - returns the database port based on mode
+Extracts port from host string if present (host:port), otherwise uses explicit port field
+*/}}
+{{- define "librenms.dbPort" -}}
+{{- if not .Values.mysql.enabled -}}
+{{- $host := required "externalDatabase.host is required when mysql.enabled is false" .Values.externalDatabase.host -}}
+{{- if contains ":" $host -}}
+{{- $host | splitList ":" | last -}}
+{{- else -}}
+{{- .Values.externalDatabase.port | default 3306 -}}
+{{- end -}}
+{{- else -}}
+{{- print "3306" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database name - returns the database name based on mode
+*/}}
+{{- define "librenms.dbName" -}}
+{{- if not .Values.mysql.enabled -}}
+{{- required "externalDatabase.name is required when mysql.enabled is false" .Values.externalDatabase.name -}}
+{{- else -}}
+{{- .Values.mysql.auth.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database user - returns the database username based on mode
+*/}}
+{{- define "librenms.dbUser" -}}
+{{- if not .Values.mysql.enabled -}}
+{{- required "externalDatabase.user is required when mysql.enabled is false" .Values.externalDatabase.user -}}
+{{- else -}}
+{{- .Values.mysql.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database timeout - returns the database timeout based on mode
+*/}}
+{{- define "librenms.dbTimeout" -}}
+{{- if not .Values.mysql.enabled -}}
+{{- .Values.externalDatabase.timeout | default 60 -}}
+{{- else -}}
+{{- print "60" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database password environment variable - returns the env var definition for DB_PASSWORD
+*/}}
+{{- define "librenms.dbPasswordEnv" -}}
+{{- if not .Values.mysql.enabled -}}
+{{- if .Values.externalDatabase.existingSecret.name -}}
+valueFrom:
+  secretKeyRef:
+    name: {{ .Values.externalDatabase.existingSecret.name }}
+    key: {{ .Values.externalDatabase.existingSecret.key | default "mysql-password" }}
+{{- else if .Values.externalDatabase.password -}}
+value: {{ .Values.externalDatabase.password | quote }}
+{{- else -}}
+{{- fail "Either externalDatabase.existingSecret.name or externalDatabase.password must be set when mysql.enabled is false" -}}
+{{- end -}}
+{{- else -}}
+valueFrom:
+  secretKeyRef:
+    name: {{ .Release.Name }}-mysql
+    key: mysql-password
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate external database configuration
+*/}}
+{{- define "librenms.validateExternalDB" -}}
+{{- if not .Values.mysql.enabled -}}
+{{- if not .Values.externalDatabase.host -}}
+{{- fail "externalDatabase.host is required when mysql.enabled is false" -}}
+{{- end -}}
+{{- if not .Values.externalDatabase.name -}}
+{{- fail "externalDatabase.name is required when mysql.enabled is false" -}}
+{{- end -}}
+{{- if not .Values.externalDatabase.user -}}
+{{- fail "externalDatabase.user is required when mysql.enabled is false" -}}
+{{- end -}}
+{{- if and (not .Values.externalDatabase.existingSecret.name) (not .Values.externalDatabase.password) -}}
+{{- fail "Either externalDatabase.existingSecret.name or externalDatabase.password must be set when mysql.enabled is false" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/librenms/templates/librenms-configmap.yml
+++ b/charts/librenms/templates/librenms-configmap.yml
@@ -5,16 +5,17 @@ metadata:
   name: {{ .Release.Name }}
 data:
   TZ: {{ .Values.librenms.timezone}}
-  DB_TIMEOUT: "60"
+  DB_TIMEOUT: {{ include "librenms.dbTimeout" . | quote }}
   REDIS_HOST: {{ .Release.Name }}-redis-master
   REDIS_PORT: "6379"
   REDIS_DB: "0"
   RRDCACHED_SERVER: "{{ .Release.Name }}-rrdcached:42217"
   CACHE_DRIVER: redis
   SESSION_DRIVER: redis
-  DB_HOST: {{ .Release.Name }}-mysql
-  DB_USERNAME: {{.Values.mysql.auth.username}}
-  DB_DATABASE: {{.Values.mysql.auth.database}}
+  DB_HOST: {{ include "librenms.dbHost" . }}
+  DB_PORT: {{ include "librenms.dbPort" . | quote }}
+  DB_USERNAME: {{ include "librenms.dbUser" . }}
+  DB_DATABASE: {{ include "librenms.dbName" . }}
 --- 
 kind: ConfigMap
 apiVersion: v1

--- a/charts/librenms/templates/librenms-cron.yml
+++ b/charts/librenms/templates/librenms-cron.yml
@@ -39,10 +39,7 @@ spec:
             {{- end }}
             env:
             - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-mysql
-                  key: mysql-password
+              {{- include "librenms.dbPasswordEnv" . | nindent 14 }}
             {{- with .Values.librenms.extraEnvs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/librenms/templates/librenms-deployment.yml
+++ b/charts/librenms/templates/librenms-deployment.yml
@@ -76,10 +76,7 @@ spec:
         {{- end }}
         env:
         - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-mysql
-              key: mysql-password
+          {{- include "librenms.dbPasswordEnv" . | nindent 10 }}
         {{- with .Values.librenms.extraEnvs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/librenms/templates/librenms-poller-ss.yml
+++ b/charts/librenms/templates/librenms-poller-ss.yml
@@ -70,10 +70,7 @@ spec:
         - name: SIDECAR_DISPATCHER
           value: "1"
         - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-mysql
-              key: mysql-password
+          {{- include "librenms.dbPasswordEnv" . | nindent 10 }}
         {{- with .Values.librenms.extraEnvs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -106,7 +103,13 @@ spec:
         {{- end }}
         readinessProbe: 
           exec:
-            command: ["nc", "-z", "-v", "-w1", "{{ .Release.Name }}-mysql", "3306"]
+            command:
+            - "nc"
+            - "-z"
+            - "-v"
+            - "-w1"
+            - {{ include "librenms.dbHost" . | quote }}
+            - {{ include "librenms.dbPort" . | quote }}
           initialDelaySeconds: 30
           periodSeconds: 10
           failureThreshold: 3

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -583,6 +583,57 @@
       "type": "object",
       "description": "LibreNMS ingress configuration",
       "additionalProperties": true
+    },
+    "externalDatabase": {
+      "type": "object",
+      "description": "External database configuration. Used when mysql.enabled is false.",
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Database host (DNS name or IP address). Supports both 'hostname' or 'hostname:port' formats. If port is included in the host field, it takes precedence over the separate port field."
+        },
+        "port": {
+          "type": "integer",
+          "description": "Database port. Optional if port is included in the host field.",
+          "default": 3306
+        },
+        "name": {
+          "type": "string",
+          "description": "Database name",
+          "default": "librenms"
+        },
+        "user": {
+          "type": "string",
+          "description": "Database username",
+          "default": "librenms"
+        },
+        "existingSecret": {
+          "type": "object",
+          "description": "Reference to existing secret containing database password",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the secret"
+            },
+            "key": {
+              "type": "string",
+              "description": "Key in the secret containing the password",
+              "default": "mysql-password"
+            }
+          }
+        },
+        "password": {
+          "type": "string",
+          "description": "Database password (plain text, not recommended for production)"
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Database connection timeout in seconds",
+          "default": 60
+        }
+      }
     }
   }
 }

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -261,6 +261,35 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- External database configuration. Used when mysql.enabled is false.
+# When mysql.enabled is true (default), the bundled MySQL subchart is used and these values are ignored.
+externalDatabase:
+  # -- DB host (DNS name or IP). Supports both "hostname" or "hostname:port" formats.
+  # If port is included in the host field, it takes precedence over the separate port field.
+  # Example: "mysql.example.svc.cluster.local", "10.0.0.12", or "mysql.example.com:3307"
+  host: ""
+  # -- DB port (MySQL default 3306). Optional if port is included in the host field.
+  port: 3306
+  # -- Database name
+  name: "librenms"
+  # -- Database username
+  user: "librenms"
+
+  # -- Where to get the DB password:
+  # Option A: reference an existing Secret (recommended for production)
+  existingSecret:
+    # -- Name of the secret containing the database password
+    name: ""
+    # -- Key in the secret that contains the database password
+    key: "mysql-password"
+
+  # Option B: literal password (not recommended for production, but useful for testing)
+  # -- Database password (plain text). Use existingSecret instead for production.
+  password: ""
+
+  # -- Optional: DB connection timeout in seconds
+  timeout: 60
+
 # -- Configuration for MySQL dependency chart by Bitnami. See their chart for
 # more information: https://github.com/bitnami/charts/tree/master/bitnami/mysql
 mysql:


### PR DESCRIPTION
### Testing/Validation
I wrote some test scripts to validate both an internal DB and an external DB with this chart. 

<details>

<summary>Testing script output: </summary>

```shell
=== LibreNMS Chart Complete Test Suite ===

This script will test both internal and external database configurations.

Select test mode:
  1) Test with internal database (default, bundled MySQL)
  2) Test with external database (separate MySQL deployment)
  3) Test both configurations
  4) Cleanup cluster and exit

Enter choice [1-4]: 3

Running comprehensive test suite...

=== Phase 1: Testing Internal Database Configuration ===

=== LibreNMS Chart Testing Script ===

[0/7] Preparing kind cluster...
Cluster 'librenms-test' already exists, cleaning resources...
Switched to context "kind-librenms-test".
Uninstalling existing helm releases...
release "external-mysql" uninstalled
release "test-librenms-ext" uninstalled
Cleaning up remaining resources...
pod "test-librenms-ext-frontend-7b8c457d6d-ck289" deleted
pod "test-librenms-ext-poller-0" deleted
pod "test-librenms-ext-poller-1" deleted
service "kubernetes" deleted
persistentvolumeclaim "data-test-librenms-mysql-0" deleted
persistentvolumeclaim "redis-data-test-librenms-ext-redis-master-0" deleted
persistentvolumeclaim "redis-data-test-librenms-redis-master-0" deleted
Waiting for cleanup to complete...
✓ Cluster cleaned

[1/7] Updating chart dependencies...
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "bitnami" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 2 charts
Downloading redis from repo https://charts.bitnami.com/bitnami
Pulled: registry-1.docker.io/bitnamicharts/redis:24.0.0
Digest: sha256:37c82701781aa30de0dfe548416481fd27216751fcecfee1a68e8244ee2b9a3a
Downloading mysql from repo https://charts.bitnami.com/bitnami
Pulled: registry-1.docker.io/bitnamicharts/mysql:14.0.3
Digest: sha256:2bbaf66e43dad7edce1eb563e19bcabd83eb8c8f79549505ad1c48e3a0cbfbba
Deleting outdated charts
✓ Dependencies updated

[2/7] Skipping default values lint (requires appkey)
✓ Skipped

[3/7] Linting chart with CI test values...
==> Linting ./charts/librenms
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
✓ Lint passed (CI test values)

[4/7] Rendering templates with CI test values...
✓ Templates rendered successfully

[5/7] Checking for existing release...
No existing release found

[6/7] Installing chart...
NAME: test-librenms
LAST DEPLOYED: Mon Dec 29 15:31:37 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
✓ Chart installed successfully

[7/7] Waiting for pods to be ready...
pod/test-librenms-mysql-0 condition met
pod/test-librenms-poller-0 condition met
pod/test-librenms-poller-1 condition met
pod/test-librenms-redis-master-0 condition met
✓ Pods are ready

=== Deployment Status ===
NAME: test-librenms
LAST DEPLOYED: Mon Dec 29 15:31:37 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None

=== Pod Status ===
NAME                           READY   STATUS    RESTARTS   AGE
test-librenms-mysql-0          1/1     Running   0          6m36s
test-librenms-poller-0         1/1     Running   0          6m36s
test-librenms-poller-1         1/1     Running   0          5m46s
test-librenms-redis-master-0   1/1     Running   0          6m36s

=== Services ===
NAME                           TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
test-librenms-mysql            ClusterIP   10.96.93.17    <none>        3306/TCP   6m37s
test-librenms-mysql-headless   ClusterIP   None           <none>        3306/TCP   6m37s
test-librenms-redis-headless   ClusterIP   None           <none>        6379/TCP   6m37s
test-librenms-redis-master     ClusterIP   10.96.78.139   <none>        6379/TCP   6m37s

=== Testing Complete ===

Next steps:
  - Check logs: kubectl logs -n default <pod-name>
  - Access cluster: kubectl config use-context kind-librenms-test
  - Cleanup: ./cleanup-cluster.sh

Port Forwarding:
Starting port-forward to LibreNMS frontend on http://localhost:8000
Press Ctrl+C to stop port-forwarding and exit

Forwarding from 127.0.0.1:8000 -> 8000
Forwarding from [::1]:8000 -> 8000
Handling connection for 8000
Handling connection for 8000
Handling connection for 8000
Handling connection for 8000
Handling connection for 8000
Handling connection for 8000
^C
Cluster remains running. Access it with:
  kubectl config use-context kind-librenms-test

✓ Internal database test completed

Press Enter to continue to external database test, or Ctrl+C to stop...


=== Phase 2: Testing External Database Configuration ===

=== LibreNMS Chart External Database Testing Script ===

[0/10] Preparing kind cluster...
Cluster 'librenms-test' already exists, using it...
Switched to context "kind-librenms-test".
✓ Using existing cluster

[1/10] Adding Bitnami Helm repository...
"bitnami" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "bitnami" chart repository
Update Complete. ⎈Happy Helming!⎈
✓ Helm repositories updated

[2/10] Deploying external MySQL database...
Installing MySQL as external database...
NAME: external-mysql
LAST DEPLOYED: Mon Dec 29 15:40:24 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
CHART NAME: mysql
CHART VERSION: 14.0.3
APP VERSION: 9.4.0

⚠ WARNING: Since August 28th, 2025, only a limited subset of images/charts are available for free.
    Subscribe to Bitnami Secure Images to receive continued support and security updates.
    More info at https://bitnami.com and https://github.com/bitnami/containers/issues/83267

** Please be patient while the chart is being deployed **

Tip:

  Watch the deployment status using the command: kubectl get pods -w --namespace default

Services:

  echo Primary: external-mysql.default.svc.cluster.local:3306

Execute the following to get the administrator credentials:

  echo Username: root
  MYSQL_ROOT_PASSWORD=$(kubectl get secret --namespace default external-mysql -o jsonpath="{.data.mysql-root-password}" | base64 -d)

To connect to your database:

  1. Run a pod that you can use as a client:

      kubectl run external-mysql-client --rm --tty -i --restart='Never' --image  docker.io/bitnamilegacy/mysql:9.4.0-debian-12-r1 --namespace default --env MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD --command -- bash

  2. To connect to primary service (read/write):

      mysql -h external-mysql.default.svc.cluster.local -uroot -p"$MYSQL_ROOT_PASSWORD"






WARNING: There are "resources" sections in the chart not set. Using "resourcesPreset" is not recommended for production. For production installations, please set the following values according to your workload needs:
  - primary.resources
  - secondary.resources
+info https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

⚠ SECURITY WARNING: Original containers have been substituted. This Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.

Substituted images detected:
  - docker.io/bitnamilegacy/mysql:9.4.0-debian-12-r1

⚠ WARNING: Original containers have been substituted for unrecognized ones. Deploying this chart with non-standard containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.

Unrecognized images:
  - docker.io/bitnamilegacy/mysql:9.4.0-debian-12-r1
✓ External MySQL deployed

[3/10] Creating database secret...
secret "librenms-mysql-external" deleted
secret/librenms-mysql-external created
✓ Database secret created

[4/10] Updating chart dependencies...
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "bitnami" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 2 charts
Downloading redis from repo https://charts.bitnami.com/bitnami
Pulled: registry-1.docker.io/bitnamicharts/redis:24.0.0
Digest: sha256:37c82701781aa30de0dfe548416481fd27216751fcecfee1a68e8244ee2b9a3a
Downloading mysql from repo https://charts.bitnami.com/bitnami
Pulled: registry-1.docker.io/bitnamicharts/mysql:14.0.3
Digest: sha256:2bbaf66e43dad7edce1eb563e19bcabd83eb8c8f79549505ad1c48e3a0cbfbba
Deleting outdated charts
✓ Dependencies updated

[5/10] Linting chart with external database configuration...
==> Linting ./charts/librenms
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
✓ Lint passed (external DB)

[6/10] Rendering templates with external database...
Verifying external DB configuration...
  ✓ DB_HOST configured correctly
  ✓ DB_PORT configured correctly
  ✓ DB_USERNAME configured correctly
  ✓ DB_DATABASE configured correctly
  ✓ External secret reference configured correctly
✓ Templates rendered successfully

[7/10] Checking for existing release...
No existing release found

[8/10] Installing chart with external database...
NAME: test-librenms-ext
LAST DEPLOYED: Mon Dec 29 15:41:32 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
✓ Chart installed successfully with external database

[9/10] Verifying external database connection...
Checking if LibreNMS can connect to external MySQL...
Testing database connection from pod: test-librenms-ext-frontend-7b8c457d6d-xkjlm
  Checking environment variables...
Defaulted container "librenms" out of: librenms, init (init)
DB_USERNAME=librenms
DB_HOST=external-mysql.default.svc.cluster.local
DB_PORT=3306
DB_DATABASE=librenms
✓ Database connection verified

[10/10] Waiting for pods to be ready...
pod/test-librenms-ext-frontend-7b8c457d6d-xkjlm condition met
pod/test-librenms-ext-poller-0 condition met
pod/test-librenms-ext-poller-1 condition met
pod/test-librenms-ext-rrdcached-78b589d457-fqdvg condition met
✓ Pods are ready

=== Deployment Status ===
NAME: test-librenms-ext
LAST DEPLOYED: Mon Dec 29 15:41:32 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None

=== Pod Status ===
NAME                                           READY   STATUS    RESTARTS   AGE
external-mysql-0                               1/1     Running   0          7m13s
test-librenms-ext-frontend-7b8c457d6d-xkjlm    1/1     Running   0          6m4s
test-librenms-ext-poller-0                     1/1     Running   0          6m4s
test-librenms-ext-poller-1                     1/1     Running   0          5m23s
test-librenms-ext-redis-master-0               1/1     Running   0          6m4s
test-librenms-ext-rrdcached-78b589d457-fqdvg   1/1     Running   0          6m4s
test-librenms-frontend-746c4df755-5zrqk        1/1     Running   0          15m
test-librenms-mysql-0                          1/1     Running   0          15m
test-librenms-poller-0                         1/1     Running   0          15m
test-librenms-poller-1                         1/1     Running   0          15m
test-librenms-redis-master-0                   1/1     Running   0          15m
test-librenms-rrdcached-786d4c8446-kwmp8       1/1     Running   0          15m

=== Services ===
NAME                                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)     AGE
external-mysql                         ClusterIP   10.96.176.112   <none>        3306/TCP    7m13s
external-mysql-headless                ClusterIP   None            <none>        3306/TCP    7m13s
kubernetes                             ClusterIP   10.96.0.1       <none>        443/TCP     16m
test-librenms                          ClusterIP   10.96.203.34    <none>        8000/TCP    15m
test-librenms-ext                      ClusterIP   10.96.136.24    <none>        8000/TCP    6m4s
test-librenms-ext-redis-headless       ClusterIP   None            <none>        6379/TCP    6m4s
test-librenms-ext-redis-master         ClusterIP   10.96.204.181   <none>        6379/TCP    6m4s
test-librenms-ext-rrdcached            ClusterIP   10.96.39.94     <none>        42217/TCP   6m4s
test-librenms-ext-rrdcached-headless   ClusterIP   None            <none>        42217/TCP   6m4s
test-librenms-mysql                    ClusterIP   10.96.93.17     <none>        3306/TCP    15m
test-librenms-mysql-headless           ClusterIP   None            <none>        3306/TCP    15m
test-librenms-redis-headless           ClusterIP   None            <none>        6379/TCP    15m
test-librenms-redis-master             ClusterIP   10.96.78.139    <none>        6379/TCP    15m
test-librenms-rrdcached                ClusterIP   10.96.24.51     <none>        42217/TCP   15m
test-librenms-rrdcached-headless       ClusterIP   None            <none>        42217/TCP   15m

=== External Database ===
MySQL Release: external-mysql
MySQL Service: external-mysql.default.svc.cluster.local:3306
Database: librenms
Username: librenms
Password: librenms123 (from secret: librenms-mysql-external)

=== Testing Complete ===

External Database Testing Completed Successfully!

Next steps:
  - Check logs: kubectl logs -n default <pod-name>
  - Access cluster: kubectl config use-context kind-librenms-test
  - Verify MySQL: kubectl exec -it external-mysql-0 -- mysql -ulibrenms -plibrenms123 librenms
  - Cleanup: ./cleanup-cluster.sh

Port Forwarding:
Starting port-forward to LibreNMS frontend on http://localhost:8001
Press Ctrl+C to stop port-forwarding and exit

Forwarding from 127.0.0.1:8001 -> 8000
Forwarding from [::1]:8001 -> 8000
Handling connection for 8001
Handling connection for 8001
Handling connection for 8001
Handling connection for 8001
Handling connection for 8001
Handling connection for 8001
^C
Cluster remains running. Access it with:
  kubectl config use-context kind-librenms-test

=== All Tests Completed Successfully ===
```
</details>

