### PR TITLE
Replace Bitnami MySQL with HelmForge MySQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ docs-%:
 	--volume "$$(pwd):/helm-docs" \
 	-u $$(id -u) \
 	jnorwood/helm-docs:$(DOCS_IMAGE_VERSION) \
-	helm-docs -c ./charts/$* -t ./README.gotmpl -o ./README.md
+	helm-docs -c ./charts/$* -t ./README.md.gotmpl -o ./README.md
 
 .PHONY: helm-deps-update
 helm-deps-update: $(addprefix helm-deps-update-, $(CHARTS_NAMES))

--- a/charts/librenms/Chart.lock
+++ b/charts/librenms/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 24.0.0
 - name: mysql
-  repository: https://charts.bitnami.com/bitnami
-  version: 14.0.3
-digest: sha256:b6e64e09a90a665d2ae0bb30029e60b353f70dc0b75384575e2f070b1ea396f8
-generated: "2025-11-28T23:23:49.480554393Z"
+  repository: https://repo.helmforge.dev
+  version: 1.8.5
+digest: sha256:c47a0c664923f007ad9737ced46648a9b5c842166f83a9c0ce2c5e6b0a6e170a
+generated: "2026-04-21T13:55:08.727613995-05:00"

--- a/charts/librenms/Chart.yaml
+++ b/charts/librenms/Chart.yaml
@@ -13,6 +13,6 @@ dependencies:
     repository: "https://charts.bitnami.com/bitnami"
     condition: redis.enabled
   - name: mysql
-    version: "~14.0.0"
-    repository: "https://charts.bitnami.com/bitnami"
+    version: "~1.8.0"
+    repository: "https://repo.helmforge.dev"
     condition: mysql.enabled

--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -28,8 +28,64 @@ $ helm install my-release librenms/librenms
 
 ### Internal Database (Default)
 
-By default, the chart deploys MySQL as part of the release (`mysql.enabled: true`).
+By default, the chart deploys [HelmForge MySQL](https://github.com/helmforgedev/charts/tree/main/charts/mysql) as part of the release (`mysql.enabled: true`).
 No additional database configuration is needed.
+
+The chart sets `collation-server=utf8mb4_unicode_ci` by default, which satisfies the
+[LibreNMS database collation requirement](https://community.librenms.org/t/new-default-database-charset-collation/14956)
+automatically on fresh installs.
+
+### Migrating from Bitnami MySQL (chart versions < 8.0.0)
+
+Chart v8.0.0 replaced the Bitnami MySQL subchart with [HelmForge MySQL](https://github.com/helmforgedev/charts/tree/main/charts/mysql). The two charts use **different data-directory layouts** on disk (Bitnami: `/bitnami/mysql`, HelmForge: `/var/lib/mysql`), so a **backup and restore is required** even though the PVC name (`data-RELEASE-mysql-0`) is unchanged.
+
+> **Note:** Replace `RELEASE` and `NAMESPACE` below with your Helm release name and Kubernetes namespace.
+
+**Step 1: Back up your database**
+
+```bash
+kubectl exec -n NAMESPACE RELEASE-mysql-0 -- mysqldump -uroot \
+  -p"$(kubectl get secret RELEASE-mysql -n NAMESPACE -o jsonpath='{.data.mysql-root-password}' | base64 -d)" \
+  --all-databases > backup.sql
+```
+
+**Step 2: Delete the old MySQL StatefulSet and its PVC**
+
+```bash
+kubectl delete statefulset RELEASE-mysql -n NAMESPACE --cascade=orphan
+kubectl delete pod RELEASE-mysql-0 -n NAMESPACE
+kubectl delete pvc data-RELEASE-mysql-0 -n NAMESPACE
+```
+
+**Step 3: Upgrade the chart**
+
+Point LibreNMS at the old Bitnami secret during the first upgrade so it can connect while HelmForge MySQL initializes:
+
+```yaml
+mysql:
+  existingAuthSecret:
+    name: RELEASE-mysql        # old Bitnami secret name
+    key: mysql-password        # old Bitnami secret key
+```
+
+```bash
+helm upgrade RELEASE ./charts/librenms -f values.yaml
+```
+
+**Step 4: Restore the backup**
+
+> **Note:** After upgrading, the HelmForge chart creates a new secret named `RELEASE-mysql-auth` (replacing the old Bitnami `RELEASE-mysql` secret).
+
+```bash
+kubectl cp backup.sql NAMESPACE/RELEASE-mysql-0:/tmp/backup.sql
+kubectl exec -n NAMESPACE RELEASE-mysql-0 -- mysql -uroot \
+  -p"$(kubectl get secret RELEASE-mysql-auth -n NAMESPACE -o jsonpath='{.data.mysql-root-password}' | base64 -d)" \
+  -e "SOURCE /tmp/backup.sql;"
+```
+
+**Step 5: Once verified, remove the `existingAuthSecret` override**
+
+After confirming everything works, remove the `mysql.existingAuthSecret` block from your values and run `helm upgrade` again. The chart will use the new HelmForge-generated secret going forward.
 
 ### External Database
 
@@ -51,7 +107,7 @@ externalDatabase:
   timeout: 60                        # database connection timeout in seconds
 ```
 
-**Note:** You can specify the port in either the `host` field (`mysql.example.com:3306`) OR the `port` field, but not both required.
+**Note:** You can specify the port in either the `host` field (`mysql.example.com:3306`) OR the `port` field, but not both.
 
 **Example with existing Kubernetes secret:**
 
@@ -79,10 +135,11 @@ externalDatabase:
 ```
 
 **Pre-requisites for external database:**
-- MySQL 5.7+ or MariaDB 10.2+
+- MySQL 8.0+ or MariaDB 10.5+
 - Database user with CREATE, ALTER, DROP, INSERT, UPDATE, DELETE privileges
 - Network connectivity from cluster to database host
-- Pre-created database (ensure `CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`)
+- MySQL server configured with `character-set-server=utf8mb4` and `collation-server=utf8mb4_unicode_ci`
+  (see [LibreNMS collation docs](https://community.librenms.org/t/new-default-database-charset-collation/14956))
 
 ## Persistence
 

--- a/charts/librenms/templates/_helpers.tpl
+++ b/charts/librenms/templates/_helpers.tpl
@@ -158,10 +158,17 @@ value: {{ .Values.externalDatabase.password | quote }}
 {{- fail "Either externalDatabase.existingSecret.name or externalDatabase.password must be set when mysql.enabled is false" -}}
 {{- end -}}
 {{- else -}}
+{{- if and .Values.mysql.existingAuthSecret .Values.mysql.existingAuthSecret.name -}}
 valueFrom:
   secretKeyRef:
-    name: {{ .Release.Name }}-mysql
-    key: mysql-password
+    name: {{ .Values.mysql.existingAuthSecret.name }}
+    key: {{ .Values.mysql.existingAuthSecret.key | default "mysql-user-password" }}
+{{- else -}}
+valueFrom:
+  secretKeyRef:
+    name: {{ .Release.Name }}-mysql-auth
+    key: mysql-user-password
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -144,7 +144,7 @@
           "properties": {
             "allowInsecureImages": {
               "type": "boolean",
-              "description": "Allow use of images from bitnamilegacy repository",
+              "description": "Allow use of images from bitnamilegacy repository (required for Redis subchart)",
               "default": true
             }
           },
@@ -632,6 +632,45 @@
           "type": "integer",
           "description": "Database connection timeout in seconds",
           "default": 60
+        }
+      }
+    },
+    "mysql": {
+      "type": "object",
+      "description": "Configuration for MySQL dependency chart by HelmForge (https://github.com/helmforgedev/charts/tree/main/charts/mysql). Additional properties are passed through to the subchart.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable bundled MySQL subchart. Set to false to use externalDatabase instead.",
+          "default": true
+        },
+        "existingAuthSecret": {
+          "oneOf": [
+            {
+              "type": "object",
+              "description": "Use an existing secret for MySQL authentication. Useful when migrating from the Bitnami MySQL subchart, which created a secret named 'RELEASE-mysql' with key 'mysql-password'.",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the existing secret containing the MySQL password"
+                },
+                "key": {
+                  "type": "string",
+                  "description": "Key in the secret containing the MySQL password",
+                  "default": "mysql-user-password"
+                }
+              },
+              "required": ["name"]
+            },
+            {
+              "type": "object",
+              "description": "Empty object disables the override (default behavior)",
+              "additionalProperties": false,
+              "maxProperties": 0
+            }
+          ]
         }
       }
     }

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Allow use of images from bitnamilegacy repository
+# Allow use of images from bitnamilegacy repository (required for Redis subchart)
 global:
   security:
     allowInsecureImages: true
@@ -261,18 +261,34 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-# -- Configuration for MySQL dependency chart by Bitnami. See their chart for
-# more information: https://github.com/bitnami/charts/tree/master/bitnami/mysql
+# -- Configuration for MySQL dependency chart by HelmForge. See their chart for
+# more information: https://github.com/helmforgedev/charts/tree/main/charts/mysql
 mysql:
   enabled: true
-  # Work around for Bitnami dropping support
-  # https://github.com/bitnami/charts/issues/35164
-  # https://github.com/bitnami/charts/issues/35256
-  image:
-    repository: bitnamilegacy/mysql
+  architecture: standalone
   auth:
     username: librenms
     database: librenms
+  # -- Use an existing secret for MySQL authentication instead of the auto-generated one.
+  # This is useful when migrating from the Bitnami MySQL subchart, which created a secret
+  # named "RELEASE-mysql" with key "mysql-password".
+  # Example for Bitnami migration:
+  #   existingAuthSecret:
+  #     name: my-release-mysql
+  #     key: mysql-password
+  existingAuthSecret: {}
+  # -- Set the default collation to utf8mb4_unicode_ci, which is required by LibreNMS.
+  # MySQL 8.4 defaults to utf8mb4_0900_ai_ci, which causes validation warnings.
+  # See: https://community.librenms.org/t/new-default-database-charset-collation/14956
+  config:
+    myCnf: |
+      [mysqld]
+      character-set-server=utf8mb4
+      collation-server=utf8mb4_unicode_ci
+  standalone:
+    persistence:
+      enabled: true
+      size: 8Gi
 
 # -- External database configuration. Used when mysql.enabled is false.
 # When mysql.enabled is true (default), the bundled MySQL subchart is used and these values are ignored.


### PR DESCRIPTION
- Switch MySQL subchart from Bitnami (v14) to HelmForge (v1.8.x)
- Update _helpers.tpl to reference HelmForge secret naming (RELEASE-mysql-auth)
- Add existingAuthSecret support for Bitnami migration path
- Set default collation to utf8mb4_unicode_ci for LibreNMS compatibility
- Rename README.gotmpl to README.md.gotmpl and update Makefile
- Update values.schema.json with mysql and existingAuthSecret validation
- Update documentation