### PR TITLE
Remove unused Bitnami chart-repo entry from ct.yaml

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -3,7 +3,6 @@ validate-maintainers: false
 target-branch: main
 chart-repos:
   - librenms=https://www.librenms.org/helm-charts/
-  - bitnami=https://charts.bitnami.com/bitnami/
 helm-extra-args: --timeout 800s
 chart-dirs:
   - charts


### PR DESCRIPTION
Both the mysql and redis subchart dependencies now come from repo.helmforge.dev, so chart-testing no longer needs the Bitnami repository registered.