### PR TITLE
Add values for APP_URL and TRUSTED_PROXIES for proper TLS termination by ingress.

### DIFF
--- a/charts/librenms/README.md
+++ b/charts/librenms/README.md
@@ -188,6 +188,23 @@ librenms:
 ```
 If both are left blank, the chart will generate and persist a random key automatically.
 
+### APP_URL and APP_TRUSTED_PROXIES
+
+When TLS is terminated at an ingress or load balancer in front of LibreNMS (the normal Kubernetes pattern), the pod itself only sees plain HTTP traffic. Without telling Laravel about the real external URL and which proxies to trust, LibreNMS
+generates all links using the HTTP schema instead of HTTPS. This results in mixed security browser content and redirects, which are generally rejected by browsers.
+
+Both values are optional and blank by default. If left unset, the corresponding `APP_URL`/`APP_TRUSTED_PROXIES` environment variables are omitted.
+
+Set `librenms.frontend.appUrl` to the externally visible URL of your instance, and `librenms.frontend.appTrustedProxies` to the proxy IPs/CIDRs in front of it (or `"*"` to trust all):
+
+```yaml
+librenms:
+  frontend:
+    appUrl: "https://librenms.example.com"
+    appTrustedProxies:
+      - "10.0.0.0/8"
+```
+
 ### Recommendations
 
 * `librenms.poller.replicas`: Depending on the scale of your installation, the amount of poller pods needs to be scaled up. Use the poller page in the LibreNMS interface to check for scaling issues.
@@ -241,6 +258,8 @@ The following table lists the main configurable parameters of the librenms chart
 | librenms.existingSecret | bool | `false` | Existing secret name to use for appkey Must have the key 'appkey' as above |
 | librenms.extraEnvFrom | list | `[]` | Extra envFrom sources applied to all LibreNMS components |
 | librenms.extraEnvs | list | `[]` | Extra environment variables applied to all LibreNMS components |
+| librenms.frontend.appTrustedProxies | list | `[]` | List of proxy IPs/CIDRs (or "*" to trust all) that terminate TLS in front of LibreNMS, so Laravel trusts their X-Forwarded-* headers and generates https:// URLs correctly. Typically your ingress controller's pod/service CIDR, or "*" if that's not known/stable. |
+| librenms.frontend.appUrl | string | `""` | The externally visible base URL of this LibreNMS instance, including scheme (e.g. "https://librenms.example.com"). Required for correct URL generation when TLS is terminated at an ingress/load balancer. |
 | librenms.frontend.enabled | bool | `true` | Frontend enabled |
 | librenms.frontend.extraEnvFrom | list | `[]` | Extra envFrom sources for frontend containers |
 | librenms.frontend.extraEnvs | list | `[]` | Extra environment variables for frontend containers |

--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -188,6 +188,23 @@ librenms:
 ```
 If both are left blank, the chart will generate and persist a random key automatically.
 
+### APP_URL and APP_TRUSTED_PROXIES
+
+When TLS is terminated at an ingress or load balancer in front of LibreNMS (the normal Kubernetes pattern), the pod itself only sees plain HTTP traffic. Without telling Laravel about the real external URL and which proxies to trust, LibreNMS
+generates all links using the HTTP schema instead of HTTPS. This results in mixed security browser content and redirects, which are generally rejected by browsers.
+
+Both values are optional and blank by default. If left unset, the corresponding `APP_URL`/`APP_TRUSTED_PROXIES` environment variables are omitted.
+
+Set `librenms.frontend.appUrl` to the externally visible URL of your instance, and `librenms.frontend.appTrustedProxies` to the proxy IPs/CIDRs in front of it (or `"*"` to trust all):
+
+```yaml
+librenms:
+  frontend:
+    appUrl: "https://librenms.example.com"
+    appTrustedProxies:
+      - "10.0.0.0/8"
+```
+
 ### Recommendations
 
 * `librenms.poller.replicas`: Depending on the scale of your installation, the amount of poller pods needs to be scaled up. Use the poller page in the LibreNMS interface to check for scaling issues.

--- a/charts/librenms/files/init.sh
+++ b/charts/librenms/files/init.sh
@@ -4,4 +4,12 @@ echo "Target: $TARGET"
 echo "APP_KEY=$(cat /data/key/appkey)" > $TARGET
 echo "NODE_ID=$(hostname)" >> $TARGET
 
+if [ -n "$APP_URL" ]; then
+  echo "APP_URL=$APP_URL" >> $TARGET
+fi
+
+if [ -n "$APP_TRUSTED_PROXIES" ]; then
+  echo "APP_TRUSTED_PROXIES=$APP_TRUSTED_PROXIES" >> $TARGET
+fi
+
 cat $TARGET

--- a/charts/librenms/templates/librenms-configmap.yml
+++ b/charts/librenms/templates/librenms-configmap.yml
@@ -16,7 +16,13 @@ data:
   DB_PORT: {{ include "librenms.dbPort" . | quote }}
   DB_USERNAME: {{ include "librenms.dbUser" . }}
   DB_DATABASE: {{ include "librenms.dbName" . }}
---- 
+  {{- if .Values.librenms.frontend.appUrl }}
+  APP_URL: {{ .Values.librenms.frontend.appUrl | quote }}
+  {{- end }}
+  {{- if .Values.librenms.frontend.appTrustedProxies }}
+  APP_TRUSTED_PROXIES: {{ .Values.librenms.frontend.appTrustedProxies | join "," | quote }}
+  {{- end }}
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/charts/librenms/templates/librenms-deployment.yml
+++ b/charts/librenms/templates/librenms-deployment.yml
@@ -46,6 +46,9 @@ spec:
           image: '{{ .Values.librenms.initContainer.image.repository }}:{{ .Values.librenms.initContainer.image.tag }}'
           imagePullPolicy: {{ .Values.librenms.initContainer.image.pullPolicy }}
           command: ["/bin/sh","/data/files/init.sh"]
+          envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}
           {{- with .Values.librenms.initContainer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -341,6 +341,19 @@
                                 }
                             ]
                         },
+                        "appUrl": {
+                            "type": "string",
+                            "description": "The externally visible base URL of this LibreNMS instance, including scheme",
+                            "default": ""
+                        },
+                        "appTrustedProxies": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "List of proxy IPs/CIDRs (or \"*\" to trust all) that terminate TLS in front of LibreNMS",
+                            "default": []
+                        },
                         "extraVolumes": {
                             "type": "array",
                             "items": {

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -100,6 +100,17 @@ librenms:
     # -- nodeSelector for frontend pods
     nodeSelector: {}
 
+    # -- The externally visible base URL of this LibreNMS instance, including
+    # scheme (e.g. "https://librenms.example.com"). Required for correct URL
+    # generation when TLS is terminated at an ingress/load balancer.
+    appUrl: ""
+
+    # -- List of proxy IPs/CIDRs (or "*" to trust all) that terminate TLS in
+    # front of LibreNMS, so Laravel trusts their X-Forwarded-* headers and
+    # generates https:// URLs correctly. Typically your ingress controller's
+    # pod/service CIDR, or "*" if that's not known/stable.
+    appTrustedProxies: []
+
     # -- Extra volumes for frontend pods
     extraVolumes: []
 


### PR DESCRIPTION
**Problem**

The helm chart had no way to pass options to Laravel for APP_URL or TRUSTED_PROXIES, and attempting to leverage `extraEnvs` applied them to the `root` users environment but did not make them available to Laravel. When TLS is being terminated at the ingress or load balancer, LibreNMS/Laravel never sees the HTTPS schema. Without providing these values to Laravel a mixed content page is generated and results in a functionally unusable interface.

**Changes**

Added values to the chart schema for: 

- `librenms.frontend.appUrl` [string]
- `librenms.frontend.appTrustedProxies` [list]

Both values default to empty and maintain previous behavior of the chart if omitted. If values are provided the `init.sh` script adds them to the `.env` file making them available to Laravel.

**Testing**

I inspected rendered templates locally and repeatedly deployed the modified chart with and without values for these new options.