### PR TITLE
feat(frontend): add appUrl and appTrustedProxies for ingress TLS termination

### DIFF
--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -188,6 +188,22 @@ librenms:
 ```
 If both are left blank, the chart will generate and persist a random key automatically.
 
+### TLS termination at an ingress (APP_URL / APP_TRUSTED_PROXIES)
+
+When TLS is terminated at an ingress or load balancer, the pod only ever sees plain HTTP, so Laravel generates `http://` links and the UI ends up serving mixed content that browsers block.
+
+Setting these through `extraEnvs` is not reliable: the LibreNMS image runs PHP-FPM with `clear_env = yes`, so container environment variables are invisible to the workers serving web requests. It appears to work only until something runs `config:clear` (for example from the admin UI), after which Laravel falls back to reading `.env` directly. These two values are written into `.env` by the init container instead, so they survive a config cache clear.
+
+Both are empty by default and omitted entirely when unset:
+
+```yaml
+librenms:
+  frontend:
+    appUrl: "https://librenms.example.com"
+    appTrustedProxies:
+      - "10.0.0.0/8"   # or "*" to trust all
+```
+
 ### Recommendations
 
 * `librenms.poller.replicas`: Depending on the scale of your installation, the amount of poller pods needs to be scaled up. Use the poller page in the LibreNMS interface to check for scaling issues.

--- a/charts/librenms/ci/test-values.yaml
+++ b/charts/librenms/ci/test-values.yaml
@@ -29,6 +29,9 @@ librenms:
         memory: 128Mi
         ephemeral-storage: 100Mi
   frontend:
+    appUrl: "https://librenms.example.com"
+    appTrustedProxies:
+      - "10.0.0.0/8"
     extraEnvs:
       - name: FRONTEND_DEBUG
         value: "true"

--- a/charts/librenms/files/init.sh
+++ b/charts/librenms/files/init.sh
@@ -4,4 +4,14 @@ echo "Target: $TARGET"
 echo "APP_KEY=$(cat /data/key/appkey)" > $TARGET
 echo "NODE_ID=$(hostname)" >> $TARGET
 
+# Laravel only reads these from .env; PHP-FPM runs with clear_env=yes so
+# container env vars are invisible to it after a config cache clear.
+if [ -n "$APP_URL" ]; then
+  echo "APP_URL=$APP_URL" >> $TARGET
+fi
+
+if [ -n "$APP_TRUSTED_PROXIES" ]; then
+  echo "APP_TRUSTED_PROXIES=$APP_TRUSTED_PROXIES" >> $TARGET
+fi
+
 cat $TARGET

--- a/charts/librenms/templates/librenms-configmap.yml
+++ b/charts/librenms/templates/librenms-configmap.yml
@@ -16,7 +16,13 @@ data:
   DB_PORT: {{ include "librenms.dbPort" . | quote }}
   DB_USERNAME: {{ include "librenms.dbUser" . }}
   DB_DATABASE: {{ include "librenms.dbName" . }}
---- 
+  {{- with .Values.librenms.frontend.appUrl }}
+  APP_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.librenms.frontend.appTrustedProxies }}
+  APP_TRUSTED_PROXIES: {{ join "," . | quote }}
+  {{- end }}
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/charts/librenms/templates/librenms-deployment.yml
+++ b/charts/librenms/templates/librenms-deployment.yml
@@ -46,6 +46,9 @@ spec:
           image: '{{ .Values.librenms.initContainer.image.repository }}:{{ .Values.librenms.initContainer.image.tag }}'
           imagePullPolicy: {{ .Values.librenms.initContainer.image.pullPolicy }}
           command: ["/bin/sh","/data/files/init.sh"]
+          envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}
           {{- with .Values.librenms.initContainer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -341,6 +341,19 @@
                                 }
                             ]
                         },
+                        "appUrl": {
+                            "type": "string",
+                            "description": "Externally visible base URL of this instance, including scheme",
+                            "default": ""
+                        },
+                        "appTrustedProxies": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "Proxy IPs/CIDRs (or \"*\") whose X-Forwarded-* headers Laravel should trust",
+                            "default": []
+                        },
                         "extraVolumes": {
                             "type": "array",
                             "items": {

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -100,6 +100,15 @@ librenms:
     # -- nodeSelector for frontend pods
     nodeSelector: {}
 
+    # -- Externally visible base URL of this instance, including scheme (e.g.
+    # "https://librenms.example.com"). Written to Laravel's .env as APP_URL so
+    # URLs are generated correctly when TLS is terminated at an ingress.
+    appUrl: ""
+
+    # -- Proxy IPs/CIDRs (or "*") whose X-Forwarded-* headers Laravel should
+    # trust. Written to Laravel's .env as APP_TRUSTED_PROXIES.
+    appTrustedProxies: []
+
     # -- Extra volumes for frontend pods
     extraVolumes: []
 


### PR DESCRIPTION
Supersedes #234 (abandoned). Original work by @rocketjetpack, rebased onto current `develop` with the review feedback applied.

## Problem

When TLS is terminated at an ingress or load balancer, the LibreNMS pod only ever sees plain HTTP. Laravel therefore generates `http://` links, the UI serves mixed content, and browsers block it — leaving the interface functionally unusable.

The chart had no way to set `APP_URL` or `APP_TRUSTED_PROXIES`.

### Why `extraEnvs` isn't a workaround

Setting them via `extraEnvs` appears to work, then breaks later. Root cause:

- The LibreNMS image runs PHP-FPM with `clear_env = yes` ([www.conf](https://github.com/librenms/docker/blob/master/rootfs/tpls/etc/php84/php-fpm.d/www.conf), defaulted in [03-config.sh](https://github.com/librenms/docker/blob/master/rootfs/etc/cont-init.d/03-config.sh)), so the container's environment is stripped from the workers that actually serve web requests.
- At boot, [04-svc-main.sh](https://github.com/librenms/docker/blob/master/rootfs/etc/cont-init.d/04-svc-main.sh) runs `artisan config:cache` once. The CLI *is* subject to normal env inheritance, so the values get baked into the cached config — which is why it looks like it works.
- Any later `config:clear` (e.g. from the LibreNMS admin UI) drops that cache. Laravel falls back to a live `env()` read inside an FPM worker, which can no longer see the OS env var — only what is physically in `.env`. Mixed content returns.

Writing the values into `.env` is what makes them durable.

## Changes

- New values `librenms.frontend.appUrl` (string) and `librenms.frontend.appTrustedProxies` (list), both empty by default.
- When set, they are emitted into the release ConfigMap and written to `.env` by the init container, so they survive a config cache clear.
- The frontend init container now gets `envFrom` the release ConfigMap so `init.sh` can see them.
- Added to `values.schema.json` (the `frontend` block is `additionalProperties: false`).
- Added non-empty examples to `ci/test-values.yaml` so chart-testing actually renders both new conditional blocks.
- Documented in `README.md.gotmpl`. `README.md` is left untouched — it is autogenerated on merge to `main`.

Behaviour is unchanged when the values are omitted.

## Usage

```yaml
librenms:
  frontend:
    appUrl: "https://librenms.example.com"
    appTrustedProxies:
      - "10.0.0.0/8"   # or "*" to trust all
```

## Testing

- `helm lint` with `ci/test-values.yaml` — passes.
- Rendered with the CI values: `APP_URL` / `APP_TRUSTED_PROXIES` present in the ConfigMap, `envFrom` present on the init container.
- Rendered with defaults: neither key is emitted; ConfigMap output is byte-identical to `develop` apart from a trailing-whitespace fix on the `---` separator.
- Schema rejects a wrong type: `at '/librenms/frontend/appTrustedProxies': got string, want array`.
