### PR TITLE
feat: add snmptrapd sidecar support

### DIFF
--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -191,6 +191,96 @@ librenms:
         storageClassName: "fast-ssd"
 ```
 
+## SNMP Traps
+
+The chart can run the LibreNMS image a second time as an `snmptrapd` sidecar, which receives
+SNMP traps on port 162 (UDP and TCP) and hands them to LibreNMS' `snmptrap.php` handler.
+See the [SNMP Trap Handler docs](https://docs.librenms.org/Extensions/SNMP-Trap-Handler/).
+
+```yaml
+librenms:
+  snmptrapd:
+    enabled: true
+    community: my-trap-community
+```
+
+LibreNMS attributes an incoming trap to a device by the **source address of the trap** and
+discards any trap it cannot match, so the sending device must already be monitored and its
+address must survive the trip to the pod. A `ClusterIP` service is enough for senders inside the
+cluster. Devices outside it need a `LoadBalancer` or `NodePort` service, and
+`externalTrafficPolicy: Local` so that kube-proxy does not SNAT the trap to a node address --
+which drops every external trap, or, if your nodes are themselves monitored, silently attributes
+all of them to the node that received them:
+
+```yaml
+librenms:
+  snmptrapd:
+    enabled: true
+    service:
+      type: LoadBalancer
+      loadBalancerIP: "10.0.0.50"
+      externalTrafficPolicy: Local
+```
+
+### Authorization
+
+By default the sidecar inherits the image's `disableAuthorization: yes`, which accepts every
+trap that arrives regardless of community string or SNMPv3 user. To enforce the configured
+credentials instead:
+
+```yaml
+librenms:
+  snmptrapd:
+    enabled: true
+    disableAuthorization: "no"
+    community: my-trap-community
+```
+
+> **Note:** `disableAuthorization` is a string. Write `"no"` in quotes — bare `no` is parsed as a
+> boolean by YAML and rejected by the values schema.
+
+### SNMPv3
+
+SNMPv3 trap authentication is configured under `librenms.snmptrapd.snmpv3`. The image ships
+placeholder passwords (`auth_pass` / `priv_pass`) that apply when none are set, so set your own.
+Rather than putting them in your values, point the chart at an existing secret:
+
+```bash
+kubectl create secret generic snmpv3-credentials \
+  --from-literal=snmp-auth-password=YOUR_AUTH_PASSWORD \
+  --from-literal=snmp-priv-password=YOUR_PRIV_PASSWORD \
+  -n default
+```
+
+```yaml
+librenms:
+  snmptrapd:
+    enabled: true
+    snmpv3:
+      user: librenms_user
+      authProtocol: SHA
+      privProtocol: AES
+      securityLevel: priv
+      engineId: "1234567890"
+      existingSecret:
+        name: snmpv3-credentials
+        authKey: snmp-auth-password
+        privKey: snmp-priv-password
+```
+
+`existingSecret.name` takes precedence over `snmpv3.authPassword` and `snmpv3.privPassword`.
+
+### MIBs
+
+The standard and Cisco MIB directories are always loaded. Add vendor directories with
+`librenms.snmptrapd.extraMibDirs` (colon separated):
+
+```yaml
+librenms:
+  snmptrapd:
+    extraMibDirs: "/opt/librenms/mibs/veeam:/opt/librenms/mibs/dell"
+```
+
 ## Values
 Check the [values.yaml](./values.yaml) file for the available settings for this chart and its dependencies.
 

--- a/charts/librenms/ci/test-values.yaml
+++ b/charts/librenms/ci/test-values.yaml
@@ -79,6 +79,24 @@ librenms:
         cpu: 50m
         memory: 128Mi
         ephemeral-storage: 100Mi
+  snmptrapd:
+    enabled: true
+    extraMibDirs: /opt/librenms/mibs
+    service:
+      annotations:
+        librenms.org/component: snmptrapd
+    extraEnvs:
+      - name: TRAP_DEBUG
+        value: "true"
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+        ephemeral-storage: 200Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+        ephemeral-storage: 100Mi
   rrdcached:
     extraEnvs:
       - name: RRD_DEBUG

--- a/charts/librenms/templates/librenms-snmptrapd-deployment.yml
+++ b/charts/librenms/templates/librenms-snmptrapd-deployment.yml
@@ -1,0 +1,158 @@
+{{- if .Values.librenms.snmptrapd.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-snmptrapd
+spec:
+  replicas: {{ .Values.librenms.snmptrapd.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/instance: snmptrapd
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include "librenms.configChecksum" . }}
+        {{- with .Values.librenms.snmptrapd.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+        app.kubernetes.io/instance: snmptrapd
+    spec:
+      {{- with .Values.librenms.snmptrapd.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: env-volume
+        emptyDir: {}
+      - name: key
+        secret:
+          secretName: {{ include "librenms.secretName" . }}
+      - name: files
+        configMap:
+          name: {{ .Release.Name }}-files
+      initContainers:
+        - name: init
+          image: '{{ .Values.librenms.initContainer.image.repository }}:{{ .Values.librenms.initContainer.image.tag }}'
+          imagePullPolicy: {{ .Values.librenms.initContainer.image.pullPolicy }}
+          command: ["/bin/sh","/data/files/init.sh"]
+          {{- with .Values.librenms.initContainer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.librenms.initContainer.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          - name: env-volume
+            mountPath: /data/env-volume
+          - name: key
+            mountPath: /data/key
+          - name: files
+            mountPath: /data/files
+      containers:
+      - name: snmptrapd
+        image: '{{ .Values.librenms.image.repository }}:{{ .Values.librenms.image.tag }}'
+        imagePullPolicy: {{ .Values.librenms.image.pullPolicy }}
+        env:
+        - name: SIDECAR_SNMPTRAPD
+          value: "1"
+        - name: DB_PASSWORD
+          {{- include "librenms.dbPasswordEnv" . | nindent 10 }}
+        {{- with .Values.librenms.snmptrapd.community }}
+        - name: LIBRENMS_SNMP_COMMUNITY
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.librenms.snmptrapd.processingType }}
+        - name: SNMP_PROCESSING_TYPE
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.librenms.snmptrapd.disableAuthorization }}
+        - name: SNMP_DISABLE_AUTHORIZATION
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.librenms.snmptrapd.extraMibDirs }}
+        - name: SNMP_EXTRA_MIB_DIRS
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.librenms.snmptrapd.snmpv3 }}
+        {{- with .user }}
+        - name: SNMP_USER
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .authProtocol }}
+        - name: SNMP_AUTH_PROTO
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .privProtocol }}
+        - name: SNMP_PRIV_PROTO
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .securityLevel }}
+        - name: SNMP_SECURITY_LEVEL
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .engineId }}
+        - name: SNMP_ENGINEID
+          value: {{ . | quote }}
+        {{- end }}
+        {{- if .existingSecret.name }}
+        - name: SNMP_AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ .existingSecret.name }}
+              key: {{ .existingSecret.authKey | default "snmp-auth-password" }}
+        - name: SNMP_PRIV
+          valueFrom:
+            secretKeyRef:
+              name: {{ .existingSecret.name }}
+              key: {{ .existingSecret.privKey | default "snmp-priv-password" }}
+        {{- else }}
+        {{- with .authPassword }}
+        - name: SNMP_AUTH
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .privPassword }}
+        - name: SNMP_PRIV
+          value: {{ . | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.librenms.extraEnvs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.librenms.snmptrapd.extraEnvs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}
+        {{- with .Values.librenms.extraEnvFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.librenms.snmptrapd.extraEnvFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: files
+          mountPath: /data/config/custom.php
+          subPath: custom.php
+          readOnly: true
+        - name: env-volume
+          mountPath: /data/.env
+          subPath: env
+        ports:
+        - name: snmptrap-udp
+          containerPort: 162
+          protocol: UDP
+        - name: snmptrap-tcp
+          containerPort: 162
+          protocol: TCP
+        {{- with .Values.librenms.snmptrapd.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/charts/librenms/templates/librenms-snmptrapd-service.yml
+++ b/charts/librenms/templates/librenms-snmptrapd-service.yml
@@ -1,0 +1,31 @@
+{{- if .Values.librenms.snmptrapd.enabled }}
+{{- $svc := .Values.librenms.snmptrapd.service }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-snmptrapd
+  {{- with $svc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $svc.type }}
+  {{- with $svc.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with $svc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: snmptrapd
+  ports:
+    - name: snmptrap-udp
+      protocol: UDP
+      port: 162
+      targetPort: 162
+    - name: snmptrap-tcp
+      protocol: TCP
+      port: 162
+      targetPort: 162
+{{- end }}

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -755,7 +755,201 @@
                             "default": []
                         }
                     }
+                },
+            "snmptrapd": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "enabled": {
+                        "type": "boolean",
+                        "description": "Enable snmptrapd",
+                        "default": false
+                    },
+                    "replicas": {
+                        "type": "integer",
+                        "description": "snmptrapd replicas",
+                        "default": 1
+                    },
+                    "community": {
+                        "type": "string",
+                        "description": "SNMP v1/v2c community string devices must send their traps with",
+                        "default": "librenmsdocker"
+                    },
+                    "processingType": {
+                        "type": "string",
+                        "description": "snmptrapd processing types (log, execute and/or net) applied to accepted traps",
+                        "default": "log,execute,net"
+                    },
+                    "disableAuthorization": {
+                        "type": "string",
+                        "enum": [
+                            "yes",
+                            "no"
+                        ],
+                        "description": "Accept traps without checking the community string or SNMPv3 user",
+                        "default": "yes"
+                    },
+                    "extraMibDirs": {
+                        "type": "string",
+                        "description": "Additional colon-separated MIB directories to load",
+                        "default": ""
+                    },
+                    "snmpv3": {
+                        "type": "object",
+                        "description": "SNMPv3 credentials used to authenticate traps",
+                        "additionalProperties": false,
+                        "properties": {
+                            "user": {
+                                "type": "string",
+                                "description": "SNMPv3 username",
+                                "default": "librenms_user"
+                            },
+                            "authProtocol": {
+                                "type": "string",
+                                "enum": [
+                                    "MD5",
+                                    "SHA"
+                                ],
+                                "description": "SNMPv3 authentication protocol",
+                                "default": "SHA"
+                            },
+                            "privProtocol": {
+                                "type": "string",
+                                "enum": [
+                                    "DES",
+                                    "AES"
+                                ],
+                                "description": "SNMPv3 privacy protocol",
+                                "default": "AES"
+                            },
+                            "securityLevel": {
+                                "type": "string",
+                                "enum": [
+                                    "noauth",
+                                    "auth",
+                                    "priv"
+                                ],
+                                "description": "SNMPv3 security level",
+                                "default": "priv"
+                            },
+                            "engineId": {
+                                "type": "string",
+                                "description": "SNMPv3 engine ID",
+                                "default": "1234567890"
+                            },
+                            "authPassword": {
+                                "type": "string",
+                                "description": "SNMPv3 authentication password",
+                                "default": ""
+                            },
+                            "privPassword": {
+                                "type": "string",
+                                "description": "SNMPv3 privacy password",
+                                "default": ""
+                            },
+                            "existingSecret": {
+                                "type": "object",
+                                "description": "Existing secret holding the SNMPv3 passwords",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the secret holding the SNMPv3 passwords",
+                                        "default": ""
+                                    },
+                                    "authKey": {
+                                        "type": "string",
+                                        "description": "Key in the secret containing the authentication password",
+                                        "default": "snmp-auth-password"
+                                    },
+                                    "privKey": {
+                                        "type": "string",
+                                        "description": "Key in the secret containing the privacy password",
+                                        "default": "snmp-priv-password"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "service": {
+                        "type": "object",
+                        "description": "Service exposing the snmptrapd receiver",
+                        "additionalProperties": false,
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "ClusterIP",
+                                    "NodePort",
+                                    "LoadBalancer"
+                                ],
+                                "description": "Service type for the trap receiver",
+                                "default": "ClusterIP"
+                            },
+                            "annotations": {
+                                "type": "object",
+                                "description": "Annotations for the snmptrapd service",
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "default": {}
+                            },
+                            "loadBalancerIP": {
+                                "type": "string",
+                                "description": "Static IP to request when type is LoadBalancer",
+                                "default": ""
+                            },
+                            "externalTrafficPolicy": {
+                                "type": "string",
+                                "enum": [
+                                    "",
+                                    "Cluster",
+                                    "Local"
+                                ],
+                                "description": "externalTrafficPolicy for the service, set to Local to preserve the trap source IP",
+                                "default": ""
+                            }
+                        }
+                    },
+                    "resources": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/resources"
+                            },
+                            {
+                                "description": "Computing resources for the snmptrapd container"
+                            }
+                        ]
+                    },
+                    "podAnnotations": {
+                        "type": "object",
+                        "description": "Pod annotations for snmptrapd pods",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "default": {}
+                    },
+                    "nodeSelector": {
+                        "$ref": "#/definitions/nodeSelector"
+                    },
+                    "extraEnvs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/envVar"
+                        },
+                        "description": "Extra environment variables for snmptrapd containers",
+                        "default": []
+                    },
+                    "extraEnvFrom": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/envFromSource"
+                        },
+                        "description": "Extra envFrom sources for snmptrapd containers",
+                        "default": []
+                    }
                 }
+            }
             }
         },
         "ingress": {

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -220,6 +220,89 @@ librenms:
     # -- Extra envFrom sources for syslogng containers
     extraEnvFrom: []
 
+  # -- snmptrapd sidecar for receiving SNMP traps from network devices on port 162.
+  # Traps are passed to LibreNMS' snmptrap.php handler, which matches them to a
+  # device by the source IP of the trap, so the sending device must already be
+  # monitored. See: https://docs.librenms.org/Extensions/SNMP-Trap-Handler/
+  snmptrapd:
+    # -- Enable snmptrapd
+    enabled: false
+    # -- snmptrapd replicas
+    replicas: 1
+    # -- SNMP v1/v2c community string devices must send their traps with.
+    # Change this from the image default before exposing the receiver.
+    community: librenmsdocker
+    # -- Which snmptrapd processing types (log, execute and/or net) to apply to
+    # accepted traps. LibreNMS needs 'execute' for its trap handler to run.
+    processingType: log,execute,net
+    # -- Accept traps without checking them against the community string or the
+    # SNMPv3 user below. Set to "no" to enforce authorization.
+    disableAuthorization: "yes"
+    # -- Additional colon-separated MIB directories to load
+    # (e.g. "/opt/librenms/mibs/veeam"). The standard and Cisco MIB directories
+    # are always loaded.
+    extraMibDirs: ""
+
+    # SNMPv3 credentials used to authenticate traps
+    snmpv3:
+      # -- SNMPv3 username
+      user: librenms_user
+      # -- SNMPv3 authentication protocol (MD5 or SHA)
+      authProtocol: SHA
+      # -- SNMPv3 privacy protocol (DES or AES)
+      privProtocol: AES
+      # -- SNMPv3 security level (noauth, auth or priv)
+      securityLevel: priv
+      # -- SNMPv3 engine ID
+      engineId: "1234567890"
+      # -- SNMPv3 authentication password. Left blank the image default
+      # ('auth_pass') applies, which should not be used in production.
+      authPassword: ""
+      # -- SNMPv3 privacy password. Left blank the image default ('priv_pass')
+      # applies, which should not be used in production.
+      privPassword: ""
+      # -- Read the SNMPv3 passwords from an existing secret instead of the two
+      # values above. Takes precedence over authPassword and privPassword.
+      existingSecret:
+        # -- Name of the secret holding the SNMPv3 passwords
+        name: ""
+        # -- Key in the secret containing the authentication password
+        authKey: "snmp-auth-password"
+        # -- Key in the secret containing the privacy password
+        privKey: "snmp-priv-password"
+
+    service:
+      # -- Service type for the trap receiver. Devices outside the cluster need
+      # LoadBalancer or NodePort to reach it.
+      type: ClusterIP
+      # -- Annotations for the snmptrapd service
+      annotations: {}
+      # -- Static IP to request when type is LoadBalancer
+      loadBalancerIP: ""
+      # -- externalTrafficPolicy for the service. Set to "Local" to preserve the
+      # source IP of incoming traps, which LibreNMS needs to match a trap to a
+      # device. Only applies to LoadBalancer and NodePort services.
+      externalTrafficPolicy: ""
+
+    # -- resources defines the computing resources (CPU and memory)
+    # that are allocated to the snmptrapd container.
+    resources: {}
+      # requests:
+      #   cpu: 100m
+      #   memory: 128M
+
+    # -- podAnnotations for snmptrapd pods
+    podAnnotations: {}
+
+    # -- nodeSelector for snmptrapd pods
+    nodeSelector: {}
+
+    # -- Extra environment variables for snmptrapd containers
+    extraEnvs: []
+
+    # -- Extra envFrom sources for snmptrapd containers
+    extraEnvFrom: []
+
   # -- RRD cached is the tool that allows for distributed polling and is mandatory
   # in this LibreNMS helm chart. See the rrdcached documentation for more
   # information: https://oss.oetiker.ch/rrdtool/doc/rrdcached.en.html


### PR DESCRIPTION
Runs the LibreNMS image a second time with `SIDECAR_SNMPTRAPD=1` so it receives SNMP traps on port 162 (UDP and TCP) and hands them to LibreNMS' `snmptrap.php` handler. Disabled by default.

It mirrors the existing syslog-ng sidecar — same init container, ConfigMap and `.env` wiring, with a matching Service — so the two read as a pair.

## Values

New `librenms.snmptrapd` block exposing the trap-specific image settings: `community`, `processingType`, `disableAuthorization`, `extraMibDirs`, and an `snmpv3` block (user, protocols, security level, engine ID, passwords), plus the usual `replicas` / `resources` / `podAnnotations` / `nodeSelector` / `extraEnvs` / `extraEnvFrom`.

```yaml
librenms:
  snmptrapd:
    enabled: true
    community: my-trap-community
```

## Additions beyond a straight syslog-ng copy

**`snmpv3.existingSecret`** — the image defaults `SNMP_AUTH` / `SNMP_PRIV` to `auth_pass` / `priv_pass`. Rather than bake credentials into a rendered Deployment, setting `existingSecret.name` switches both to a `secretKeyRef` and takes precedence over the literal password values.

**A `service` block** (`type`, `annotations`, `loadBalancerIP`, `externalTrafficPolicy`). At its defaults it renders byte-identical to syslog-ng's bare ClusterIP Service; it exists so the source address of a trap can be preserved.

LibreNMS attributes a trap to a device purely by the packet's source address — [`Trap.php`](https://github.com/librenms/librenms/blob/master/LibreNMS/Snmptrap/Trap.php) falls back from `findByHostname` to `findByIp`, and both are derived from it, since nothing in the trap payload identifies the sender. `Dispatcher.php` discards any trap it cannot match to a device.

For `NodePort` and `LoadBalancer` services under the default `externalTrafficPolicy: Cluster`, kube-proxy may forward the packet to a pod on another node and SNATs the source to the node address so the reply routes back. The pod then sees the node, not the device. Either every external trap is dropped, or — if the nodes are themselves monitored, which is common in a LibreNMS deployment — every trap from every device is attributed to the node that received it, which looks like it is working. `externalTrafficPolicy: Local` avoids the SNAT, at the cost of only scheduling traffic to nodes actually running a snmptrapd pod.

### This is not trap-specific, and syslog-ng has the same gap

The existing syslog-ng sidecar is exposed to the same behaviour. The image's `syslog-ng.conf` sets `use_dns(no)` and never sets `keep-hostname()`, whose default is `no` — so syslog-ng overwrites the message's HOSTNAME field with the sender's address before handing `$HOST` to `syslog.php`. Under SNAT that becomes the node address too.

syslog-ng is unchanged in this PR. It carries the same exposure and is handled separately.

## Notes

- `disableAuthorization` is a string, so the schema rejects bare `no` (YAML parses it as a boolean). Documented in the README template, since it is easy to hit.
- Generated `README.md` is intentionally not in this PR — only the hand-edited `README.md.gotmpl`. `release.yml` regenerates it on merge to main.
- No chart version bump, matching the syslog-ng PR; `develop` already carries 9.1.1 against main's 9.1.0.

## Verification

- `helm template` renders correctly for the default (disabled), CI values, `existingSecret`, literal-password, and LoadBalancer paths.
- `helm lint` passes with both default and CI values.
- Schema rejects unknown keys (`additionalProperties: false`), bad enum values, and the `disableAuthorization` boolean footgun.
- `ci/test-values.yaml` enables the sidecar and gives non-empty values for the empty-by-default fields it adds.

Not covered locally: `make lint` (chart-testing) needs `helm repo add` for `repo.helmforge.dev` inside the container and fails while building dependencies. CI performs that step.

