### PR TITLE
feat(syslogng): expose service type and traffic policy to preserve source IP

### DIFF
--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -191,6 +191,73 @@ librenms:
         storageClassName: "fast-ssd"
 ```
 
+## Syslog
+
+The chart can run the LibreNMS image as a `syslog-ng` sidecar, which receives syslog on port 514
+(UDP and TCP) and pipes each message to LibreNMS' `syslog.php`. See the
+[Syslog docs](https://docs.librenms.org/Extensions/Syslog/).
+
+```yaml
+librenms:
+  syslogng:
+    enabled: true
+  configuration: |
+    $config['distributed_poller_group'] = '0';
+    $config['distributed_poller']       = true;
+    $config['enable_syslog']            = true;
+```
+
+`$config['enable_syslog']` is required — without it the sidecar receives messages but LibreNMS
+does not store them.
+
+### Receiving syslog from outside the cluster
+
+LibreNMS resolves each message to a device by matching syslog-ng's `$HOST` against the device's
+hostname, sysName or IP, and **discards any message it cannot match**. The image's
+`syslog-ng.conf` sets `use_dns(no)` and leaves `keep-hostname()` at its default of `no`, which
+means syslog-ng overwrites the message's HOSTNAME field with the **address the packet came
+from**. Device attribution therefore depends on the source address surviving the trip to the pod.
+
+A `ClusterIP` service is enough for senders inside the cluster. For devices outside it, a
+`LoadBalancer` or `NodePort` service under the default `externalTrafficPolicy: Cluster` lets
+kube-proxy SNAT the source to a node address — which drops every external message, or, if your
+nodes are themselves monitored, files all of them against the node that received them. Set
+`externalTrafficPolicy: Local` to avoid the SNAT:
+
+```yaml
+librenms:
+  syslogng:
+    enabled: true
+    replicas: 1
+    service:
+      type: LoadBalancer
+      externalTrafficPolicy: Local
+      annotations:
+        metallb.io/loadBalancerIPs: 192.168.1.50
+```
+
+The same applies to the [snmptrapd sidecar](#snmp-traps), which has an identical `service` block.
+
+#### Notes for MetalLB
+
+MetalLB [respects `externalTrafficPolicy`](https://metallb.io/usage/#traffic-policies) in both L2
+and BGP mode, and documents that under `Local` "your pods can see the real source IP address of
+incoming connections". A few things worth knowing:
+
+- Prefer the `metallb.io/loadBalancerIPs` annotation over the chart's `loadBalancerIP` value.
+  MetalLB honours both, but `spec.loadBalancerIP` is deprecated in the Kubernetes API. Use
+  `metallb.io/address-pool` instead if you only care which pool the address comes from.
+- Under `Local`, only nodes running a pod attract traffic. With `replicas: 1` the announcement
+  follows the pod, so a reschedule causes a brief gap — unavoidable for UDP, which has no
+  retransmit.
+- **Syslog and traps cannot share one address** while either uses `Local`. MetalLB's
+  `metallb.io/allow-shared-ip` requires both services to use `Cluster`, or to select the *exact*
+  same pods; the syslog-ng and snmptrapd services select different pods. Give them separate
+  addresses.
+- A single service carrying both TCP and UDP needs MetalLB 0.13.6+ (which
+  [validated mixed-protocol services](https://github.com/metallb/metallb/issues/1050)) and
+  Kubernetes 1.26+, where `MixedProtocolLBService` reached GA.
+
 ## SNMP Traps
 
 The chart can run the LibreNMS image a second time as an `snmptrapd` sidecar, which receives
@@ -218,9 +285,13 @@ librenms:
     enabled: true
     service:
       type: LoadBalancer
-      loadBalancerIP: "10.0.0.50"
       externalTrafficPolicy: Local
+      annotations:
+        metallb.io/loadBalancerIPs: 192.168.1.51
 ```
+
+If you run MetalLB, see [Notes for MetalLB](#notes-for-metallb) above — in particular, traps and
+syslog need separate addresses when either uses `Local`.
 
 ### Authorization
 

--- a/charts/librenms/ci/test-values.yaml
+++ b/charts/librenms/ci/test-values.yaml
@@ -67,6 +67,9 @@ librenms:
         ephemeral-storage: 250Mi
   syslogng:
     enabled: true
+    service:
+      annotations:
+        librenms.org/component: syslogng
     extraEnvs:
       - name: SYSLOG_DEBUG
         value: "true"

--- a/charts/librenms/templates/librenms-syslog-service.yml
+++ b/charts/librenms/templates/librenms-syslog-service.yml
@@ -1,9 +1,21 @@
 {{- if .Values.librenms.syslogng.enabled }}
+{{- $svc := .Values.librenms.syslogng.service }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-syslogng
+  {{- with $svc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  type: {{ $svc.type }}
+  {{- with $svc.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with $svc.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ .Release.Name }}
     app.kubernetes.io/instance: syslogng

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -738,7 +738,47 @@
                         "nodeSelector": {
                             "$ref": "#/definitions/nodeSelector"
                         },
-                        "extraEnvs": {
+                        "service": {
+                "type": "object",
+                "description": "Service exposing the syslog receiver",
+                "additionalProperties": false,
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "ClusterIP",
+                            "NodePort",
+                            "LoadBalancer"
+                        ],
+                        "description": "Service type for the syslog receiver",
+                        "default": "ClusterIP"
+                    },
+                    "annotations": {
+                        "type": "object",
+                        "description": "Annotations for the syslogng service",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "default": {}
+                    },
+                    "loadBalancerIP": {
+                        "type": "string",
+                        "description": "Static IP to request when type is LoadBalancer",
+                        "default": ""
+                    },
+                    "externalTrafficPolicy": {
+                        "type": "string",
+                        "enum": [
+                            "",
+                            "Cluster",
+                            "Local"
+                        ],
+                        "description": "externalTrafficPolicy for the service, set to Local to preserve the source IP of incoming messages",
+                        "default": ""
+                    }
+                }
+            },
+            "extraEnvs": {
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/envVar"

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -214,6 +214,19 @@ librenms:
     # -- nodeSelector for syslogng pods
     nodeSelector: {}
 
+    service:
+      # -- Service type for the syslog receiver. Devices outside the cluster need
+      # LoadBalancer or NodePort to reach it.
+      type: ClusterIP
+      # -- Annotations for the syslogng service
+      annotations: {}
+      # -- Static IP to request when type is LoadBalancer
+      loadBalancerIP: ""
+      # -- externalTrafficPolicy for the service. Set to "Local" to preserve the
+      # source IP of incoming messages, which LibreNMS needs to match a message
+      # to a device. Only applies to LoadBalancer and NodePort services.
+      externalTrafficPolicy: ""
+
     # -- Extra environment variables for syslogng containers
     extraEnvs: []
 


### PR DESCRIPTION
Follow-up to #248, which flagged this. The syslog-ng sidecar has the same source-address dependency as snmptrapd, so it gets the same `service` block: `type`, `annotations`, `loadBalancerIP` and `externalTrafficPolicy`.

## The problem

The image's `syslog-ng.conf` sets `use_dns(no)` and never sets `keep-hostname()`, whose default is `no` — so syslog-ng **overwrites the message's HOSTNAME field with the address the packet arrived from** before handing `$HOST` to `syslog.php`. `process_syslog()` then resolves that value against the device `hostname`, `sysName` or `ip`, and [drops the message entirely](https://github.com/librenms/librenms/blob/master/includes/syslog.php) when nothing matches — everything is gated on `if ($entry['device_id'])`.

For `NodePort` and `LoadBalancer` services under the default `externalTrafficPolicy: Cluster`, kube-proxy may forward the packet to a pod on another node and SNATs the source to the node address so the reply routes back. External messages are then either discarded, or — if the nodes are themselves monitored, which is common in a LibreNMS deployment — all filed against the node that received them.

There was previously no way to set `Local` from the chart.

## The change

```yaml
librenms:
  syslogng:
    enabled: true
    service:
      type: LoadBalancer
      externalTrafficPolicy: Local
      annotations:
        metallb.io/loadBalancerIPs: 192.168.1.50
```

Identical in shape to the snmptrapd block from #248, so configuring both sidecars is the same exercise twice rather than two different ones.

## Docs

Adds a `## Syslog` section — it was previously undocumented beyond the values table — covering enablement, the `$config['enable_syslog']` requirement, the source-address behaviour above, and a **Notes for MetalLB** subsection that both sidecars link to:

- Prefer the `metallb.io/loadBalancerIPs` annotation over the chart's `loadBalancerIP` value, since `spec.loadBalancerIP` is deprecated in the Kubernetes API.
- Under `Local`, only nodes running a pod attract traffic; at `replicas: 1` the announcement follows the pod, so a reschedule causes a brief gap. Unavoidable for UDP.
- **Syslog and traps cannot share one MetalLB address** while either uses `Local` — `metallb.io/allow-shared-ip` requires both services to use `Cluster` or to select the *exact* same pods, and these two select different pods. They need separate addresses.
- A single service carrying both TCP and UDP needs MetalLB 0.13.6+ ([mixed-protocol validation](https://github.com/metallb/metallb/issues/1050)) and Kubernetes 1.26+, where `MixedProtocolLBService` reached GA.

## Compatibility

Defaults unchanged. For an existing `syslogng.enabled: true` install the rendered Service gains exactly one line, `type: ClusterIP`, which is already the API default — verified by diffing the rendered output against `develop`. No recreation, no IP change.

## Verification

- `helm template` checked for default (disabled), CI values, and the LoadBalancer + `Local` + annotations path.
- `helm lint` passes with default and CI values.
- Schema rejects bad `externalTrafficPolicy` and `type` values and unknown keys.
- `ci/test-values.yaml` exercises `syslogng.service.annotations`.

Not covered locally: `make lint` (chart-testing) needs `helm repo add` for `repo.helmforge.dev` inside the container and fails while building dependencies. CI performs that step.

