### PR TITLE
feat(gateway): add Gateway API HTTPRoute for the frontend

### DIFF
--- a/.github/workflows/chart-testing.yml
+++ b/.github/workflows/chart-testing.yml
@@ -49,6 +49,10 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true' || github.event.pull_request.base.ref == 'main' 
         uses: helm/kind-action@v1.14.0
 
+      - name: Install Gateway API CRDs
+        if: steps.list-changed.outputs.changed == 'true' || github.event.pull_request.base.ref == 'main'
+        run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true' && github.ref != 'refs/heads/develop'
         run: ct install --target-branch ${{ github.event.repository.default_branch }} --skip-clean-up

--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -191,6 +191,55 @@ librenms:
         storageClassName: "fast-ssd"
 ```
 
+## Gateway API
+
+As an alternative to `ingress`, the chart can expose the frontend with a Gateway API
+[`HTTPRoute`](https://gateway-api.sigs.k8s.io/api-types/httproute/). The Gateway itself is **not**
+created by this chart — it is normally shared across namespaces and managed separately — so this
+attaches a route to a Gateway you already run.
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - librenms.example.com
+  paths:
+    - path: /
+      pathType: PathPrefix
+
+ingress:
+  enabled: false
+```
+
+Each entry in `paths` becomes one HTTPRoute rule backed by the frontend service on port 8000.
+`ingress` and `gateway` are independent; leave `ingress.enabled: false` if you only want the route.
+
+Requires the Gateway API CRDs to be installed in the cluster and a controller implementing them.
+`HTTPRoute` has been stable at `gateway.networking.k8s.io/v1` since Gateway API v1.0.
+
+When the Gateway terminates TLS, set `librenms.frontend.appUrl` and
+`librenms.frontend.appTrustedProxies` as described under
+[TLS termination at an ingress](#tls-termination-at-an-ingress-app_url--app_trusted_proxies) —
+a Gateway is just another proxy in front of LibreNMS, and the same Laravel settings apply.
+
+### Why only the frontend
+
+The syslog-ng and snmptrapd sidecars are deliberately left on plain Services and have no route
+equivalent here. `UDPRoute` and `TCPRoute` are stable in the Gateway API standard channel, but a
+Gateway is an in-cluster proxy: the sidecar would see the **Gateway's** address rather than the
+sending device's, and LibreNMS resolves both syslog messages and traps to a device by that
+address. HTTP solves this with `X-Forwarded-For`; raw syslog and SNMP traps have no equivalent,
+and neither `snmptrapd` nor `syslog.php` speaks PROXY protocol — which is TCP-only in any case,
+while both protocols are predominantly UDP.
+
+For those two, expose the Service directly and preserve the source address with
+`externalTrafficPolicy: Local`, as described under
+[Receiving syslog from outside the cluster](#receiving-syslog-from-outside-the-cluster).
+
 ## Syslog
 
 The chart can run the LibreNMS image as a `syslog-ng` sidecar, which receives syslog on port 514

--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -229,12 +229,14 @@ a Gateway is just another proxy in front of LibreNMS, and the same Laravel setti
 ### Why only the frontend
 
 The syslog-ng and snmptrapd sidecars are deliberately left on plain Services and have no route
-equivalent here. `UDPRoute` and `TCPRoute` are stable in the Gateway API standard channel, but a
-Gateway is an in-cluster proxy: the sidecar would see the **Gateway's** address rather than the
-sending device's, and LibreNMS resolves both syslog messages and traps to a device by that
-address. HTTP solves this with `X-Forwarded-For`; raw syslog and SNMP traps have no equivalent,
-and neither `snmptrapd` nor `syslog.php` speaks PROXY protocol — which is TCP-only in any case,
-while both protocols are predominantly UDP.
+equivalent here. `UDPRoute` and `TCPRoute` are GA at `v1`, so this is not a maturity limitation.
+
+Gateway implementations terminate and forward connections, and whether the sender's address
+reaches the backend is implementation-defined rather than guaranteed by the API. LibreNMS
+resolves both syslog messages and traps to a device by that address and discards what it cannot
+match, so the guarantee matters. HTTP carries the original client in `X-Forwarded-For`, which is
+why the frontend is unaffected. Raw syslog and SNMP traps have no equivalent, and PROXY protocol
+is TCP-only while both protocols are predominantly UDP.
 
 For those two, expose the Service directly and preserve the source address with
 `externalTrafficPolicy: Local`, as described under
@@ -291,7 +293,7 @@ The same applies to the [snmptrapd sidecar](#snmp-traps), which has an identical
 
 MetalLB [respects `externalTrafficPolicy`](https://metallb.io/usage/#traffic-policies) in both L2
 and BGP mode, and documents that under `Local` "your pods can see the real source IP address of
-incoming connections". A few things worth knowing:
+incoming connections". Notes:
 
 - Prefer the `metallb.io/loadBalancerIPs` annotation over the chart's `loadBalancerIP` value.
   MetalLB honours both, but `spec.loadBalancerIP` is deprecated in the Kubernetes API. Use

--- a/charts/librenms/ci/test-values.yaml
+++ b/charts/librenms/ci/test-values.yaml
@@ -122,3 +122,15 @@ librenms:
         ephemeral-storage: 500Mi
 ingress:
   enabled: true
+gateway:
+  enabled: true
+  annotations:
+    librenms.org/component: frontend
+  parentRefs:
+    - name: ci-gateway
+      sectionName: http
+  hostnames:
+    - librenms.ci.example.com
+  paths:
+    - path: /
+      pathType: PathPrefix

--- a/charts/librenms/templates/httproute.yml
+++ b/charts/librenms/templates/httproute.yml
@@ -1,0 +1,36 @@
+{{- if .Values.gateway.enabled -}}
+{{- if not .Values.librenms.frontend.enabled -}}
+{{- fail "gateway.enabled requires librenms.frontend.enabled, the HTTPRoute has no backend otherwise" -}}
+{{- end -}}
+{{- if not .Values.gateway.parentRefs -}}
+{{- fail "gateway.parentRefs must name at least one Gateway when gateway.enabled is true" -}}
+{{- end -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/instance: frontend
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.paths }}
+    - matches:
+        - path:
+            type: {{ .pathType | default "PathPrefix" }}
+            value: {{ .path | quote }}
+      backendRefs:
+        - name: {{ $.Release.Name }}
+          port: 8000
+    {{- end }}
+{{- end }}

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -992,7 +992,100 @@
             }
             }
         },
-        "ingress": {
+        "gateway": {
+        "type": "object",
+        "description": "Gateway API HTTPRoute configuration for the frontend",
+        "additionalProperties": false,
+        "properties": {
+            "enabled": {
+                "type": "boolean",
+                "description": "Enable or disable the HTTPRoute",
+                "default": false
+            },
+            "annotations": {
+                "type": "object",
+                "description": "Annotations for the HTTPRoute",
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "default": {}
+            },
+            "parentRefs": {
+                "type": "array",
+                "description": "Gateways this route attaches to, required when enabled",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "type": "string",
+                            "description": "API group of the parent, defaults to gateway.networking.k8s.io"
+                        },
+                        "kind": {
+                            "type": "string",
+                            "description": "Kind of the parent, defaults to Gateway"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name of the Gateway"
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace of the Gateway, defaults to the release namespace"
+                        },
+                        "sectionName": {
+                            "type": "string",
+                            "description": "Name of the Gateway listener to attach to"
+                        },
+                        "port": {
+                            "type": "integer",
+                            "description": "Port of the Gateway listener to attach to"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "additionalProperties": false
+                },
+                "default": []
+            },
+            "hostnames": {
+                "type": "array",
+                "description": "Hostnames this route matches",
+                "items": {
+                    "type": "string"
+                },
+                "default": []
+            },
+            "paths": {
+                "type": "array",
+                "description": "Path matches, each becoming an HTTPRoute rule backed by the frontend service",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Path value to match"
+                        },
+                        "pathType": {
+                            "type": "string",
+                            "enum": [
+                                "Exact",
+                                "PathPrefix",
+                                "RegularExpression"
+                            ],
+                            "description": "Path match type",
+                            "default": "PathPrefix"
+                        }
+                    },
+                    "required": [
+                        "path"
+                    ],
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    "ingress": {
             "type": "object",
             "description": "LibreNMS ingress configuration",
             "additionalProperties": true

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -406,6 +406,37 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- LibreNMS Gateway API configuration. Renders an HTTPRoute for the frontend as
+# an alternative to `ingress`, for clusters running a Gateway API implementation.
+# The Gateway itself is not created by this chart -- it is usually shared across
+# namespaces and managed separately. Requires the Gateway API CRDs (HTTPRoute is
+# stable at gateway.networking.k8s.io/v1 as of Gateway API v1.0).
+#
+# Only the frontend is exposed this way. The syslog-ng and snmptrapd sidecars are
+# deliberately left on plain Services: routing them through a Gateway replaces the
+# sender's address with the Gateway's, and LibreNMS resolves a message or trap to a
+# device by that address. See the Syslog section of the README.
+gateway:
+  # -- Enable or disable the HTTPRoute
+  enabled: false
+  # -- Annotations for the HTTPRoute
+  annotations: {}
+  # -- Gateways this route attaches to. Required when enabled. Each entry accepts
+  # the usual parentRef fields (name, namespace, sectionName, port).
+  parentRefs: []
+    # - name: my-gateway
+    #   namespace: gateway-system
+    #   sectionName: https
+  # -- Hostnames this route matches. Leave empty to match every hostname the
+  # parent Gateway listener accepts.
+  hostnames: []
+    # - librenms.example.com
+  # -- Path matches. Each entry becomes an HTTPRoute rule backed by the frontend
+  # service on port 8000.
+  paths:
+    - path: /
+      pathType: PathPrefix
+
 # -- Configuration for MySQL dependency chart by HelmForge. See their chart for
 # more information: https://github.com/helmforgedev/charts/tree/main/charts/mysql
 mysql:


### PR DESCRIPTION
Adds an optional Gateway API `HTTPRoute` for the frontend as an alternative to the Ingress. Disabled by default and independent of `ingress.enabled`; existing installs are unaffected.

The Gateway is not created by the chart. `gateway.parentRefs` attaches the route to an existing one.

```yaml
gateway:
  enabled: true
  parentRefs:
    - name: shared-gateway
      namespace: gateway-system
      sectionName: https
  hostnames:
    - librenms.example.com
  paths:
    - path: /
      pathType: PathPrefix

ingress:
  enabled: false
```

Each entry in `paths` becomes one HTTPRoute rule backed by the frontend service on port 8000. Rendered at `gateway.networking.k8s.io/v1`, GA since Gateway API v1.0.

## Validation

Template guards fail with an explanation rather than rendering an unusable route:

- `gateway.enabled` with no `parentRefs`
- `gateway.enabled` with `librenms.frontend.enabled: false`, which would leave the route without a backend

The values schema requires `name` on each parentRef and constrains `pathType` to `Exact`, `PathPrefix` and `RegularExpression`, matching the CRD enum.

## Frontend only

The syslog-ng and snmptrapd sidecars remain on plain Services. Gateway implementations terminate and forward connections, and whether the sender's address reaches the backend is implementation-defined rather than guaranteed by the API. LibreNMS resolves both syslog messages and traps to a device by that address and discards what it cannot match (#248, #249). HTTP carries the original client in `X-Forwarded-For`, which is why the frontend is unaffected and why `APP_URL` / `APP_TRUSTED_PROXIES` continue to apply when the Gateway terminates TLS. Syslog and SNMP traps have no equivalent, and PROXY protocol is TCP-only while both protocols are predominantly UDP.

`UDPRoute` and `TCPRoute` are GA at `v1`; this is a source-address constraint, not a maturity one.

## CI

kind creates a vanilla cluster with no Gateway API CRDs, so `chart-testing.yml` now applies the standard bundle after cluster creation, and `ci/test-values.yaml` enables the route:

```yaml
- name: Install Gateway API CRDs
  run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
```

No controller is required. `ct install` waits on pods rather than routes, and an HTTPRoute naming a Gateway that does not exist is still accepted by the API server.

This puts the rendered route through the CRD's structural and CEL validation, which the values schema and `helm lint` do not cover. Verified on a local kind cluster: the rendered route is accepted, while a path without a leading slash and an out-of-range `backendRef` port are both rejected.
