### PR TITLE
fix(secret): preserve the generated APP_KEY across upgrades

### DIFF
--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -429,6 +429,11 @@ librenms:
 ```
 If both are left blank, the chart will generate and persist a random key automatically.
 
+The generated key is read back from the release Secret on each `helm upgrade`, so it stays
+stable for the life of the release. Rotating APP_KEY logs out every session and makes
+existing Laravel-encrypted values undecryptable, so it only changes if you set
+`librenms.appkey` explicitly.
+
 ### TLS termination at an ingress (APP_URL / APP_TRUSTED_PROXIES)
 
 When TLS is terminated at an ingress or load balancer, the pod only ever sees plain HTTP, so Laravel generates `http://` links and the UI ends up serving mixed content that browsers block.

--- a/charts/librenms/templates/librenms-secret.yml
+++ b/charts/librenms/templates/librenms-secret.yml
@@ -1,4 +1,23 @@
 {{- if not .Values.librenms.existingSecret }}
+{{- $appkey := "" -}}
+{{- if .Values.librenms.appkey -}}
+{{- $appkey = .Values.librenms.appkey -}}
+{{- else -}}
+{{- /*
+Reuse the key already stored in the cluster. Without this, every `helm upgrade`
+renders a fresh randAlphaNum and rotates APP_KEY, which invalidates all sessions
+and makes existing Laravel-encrypted values undecryptable.
+lookup returns an empty dict under `helm template` and client-side dry-run, so a
+random key is still generated there.
+*/ -}}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace .Release.Name) | default dict -}}
+{{- $data := (get $existing "data") | default dict -}}
+{{- if hasKey $data "appkey" -}}
+{{- $appkey = index $data "appkey" | b64dec -}}
+{{- else -}}
+{{- $appkey = printf "base64:%s" (randAlphaNum 32 | b64enc) -}}
+{{- end -}}
+{{- end -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -6,5 +25,5 @@ metadata:
   name: {{ .Release.Name }}
 type: Opaque
 stringData:
-  appkey: {{ if .Values.librenms.appkey }}{{ .Values.librenms.appkey | quote }}{{ else }}{{ printf "base64:%s" (randAlphaNum 32 | b64enc) | quote }}{{ end }}
+  appkey: {{ $appkey | quote }}
 {{- end }}


### PR DESCRIPTION
## Problem

`templates/librenms-secret.yml` generated the Laravel APP_KEY with `randAlphaNum` and no `lookup`. Helm re-renders templates on every `helm upgrade`, so each upgrade produced a new key and patched it over the stored one.

Effects on every upgrade of a release that does not set `librenms.appkey`:

- all sessions are invalidated and users are logged out
- values encrypted by Laravel under the previous key can no longer be decrypted

The documented behaviour was already the intended one. `README.md.gotmpl` states the key is generated "on first install and persists it in a Kubernetes Secret"; the template did not implement it.

## Change

Read the existing value back from the release Secret and generate a key only when none is stored.

Precedence is unchanged:

1. `librenms.existingSecret` suppresses the Secret entirely
2. `librenms.appkey`, when set, is used verbatim
3. otherwise the stored key is reused, and a new one is generated only on first install

`lookup` returns an empty dict under `helm template` and client-side dry-run, so offline rendering still emits a random key.

## Verification

Install followed by two upgrades on a kind cluster, comparing the stored Secret at each step.

Before:

```
install : base64:dGI0UEQ1VEFkeFNEY3lNWVhaV1ZhM2pTSVNYVTJhbTU=
upgrade1: base64:MWxPbXpJVlU5NTRhajlKU1B2Mk9Sa1R4UzFZOVNzclo=
upgrade2: base64:WFVuVDZRWWdjcWhxV2RiU0VkcWhUU2pDQ1lXblNMYko=
```

After:

```
install : base64:b1UxekdwY1dmbDZVUDFrbUhyTDBOckF6WDJodXhJSnU=
upgrade1: base64:b1UxekdwY1dmbDZVUDFrbUhyTDBOckF6WDJodXhJSnU=
upgrade2: base64:b1UxekdwY1dmbDZVUDFrbUhyTDBOckF6WDJodXhJSnU=
```

Also confirmed on the same cluster:

- setting `librenms.appkey` on upgrade overwrites the stored key
- clearing it again keeps the previously stored key rather than generating a new one
- `librenms.existingSecret` still renders no Secret

Not covered by CI: `ct install --upgrade` runs only on PRs targeting `main`, and it asserts that the upgrade succeeds, not that APP_KEY is preserved.
