### PR TITLE
fix(configmap): gate Redis and RRDCached settings on their toggles

### DIFF
--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -170,6 +170,27 @@ externalDatabase:
 - MySQL server configured with `character-set-server=utf8mb4` and `collation-server=utf8mb4_unicode_ci`
   (see [LibreNMS collation docs](https://community.librenms.org/t/new-default-database-charset-collation/14956))
 
+## Redis
+
+Redis backs the Laravel cache and session stores. The chart deploys a bundled Redis by
+default (`redis.enabled: true`).
+
+To use a Redis you manage yourself, disable the bundled one and point `externalRedis` at it:
+
+```yaml
+redis:
+  enabled: false
+externalRedis:
+  host: redis.example.internal
+  port: 6379
+  db: 0
+```
+
+With `redis.enabled: false` and no `externalRedis.host`, the chart sets the cache and
+session drivers to `file`. Pods then keep cache and session state on their own
+filesystems, so this is only safe for a single frontend replica and is not suitable for
+distributed polling.
+
 ## Persistence
 
 RRDCached uses persistent storage for time-series database files. Two separate PersistentVolumeClaims are configured:

--- a/charts/librenms/templates/_helpers.tpl
+++ b/charts/librenms/templates/_helpers.tpl
@@ -184,6 +184,49 @@ valueFrom:
 {{- end -}}
 
 {{/*
+Redis is in use when either the bundled subchart is enabled or an external host
+is configured. Without one, LibreNMS falls back to the file cache/session driver.
+*/}}
+{{- define "librenms.redisEnabled" -}}
+{{- if or .Values.redis.enabled .Values.externalRedis.host -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis host - bundled subchart service or the configured external host
+*/}}
+{{- define "librenms.redisHost" -}}
+{{- if .Values.redis.enabled -}}
+{{- printf "%s-redis-client" .Release.Name -}}
+{{- else -}}
+{{- .Values.externalRedis.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis port
+*/}}
+{{- define "librenms.redisPort" -}}
+{{- if .Values.redis.enabled -}}
+{{- print "6379" -}}
+{{- else -}}
+{{- .Values.externalRedis.port | default 6379 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis database number
+*/}}
+{{- define "librenms.redisDb" -}}
+{{- if .Values.redis.enabled -}}
+{{- print "0" -}}
+{{- else -}}
+{{- .Values.externalRedis.db | default 0 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Validate external database configuration
 */}}
 {{- define "librenms.validateExternalDB" -}}

--- a/charts/librenms/templates/librenms-configmap.yml
+++ b/charts/librenms/templates/librenms-configmap.yml
@@ -6,12 +6,22 @@ metadata:
 data:
   TZ: {{ .Values.librenms.timezone}}
   DB_TIMEOUT: {{ include "librenms.dbTimeout" . | quote }}
-  REDIS_HOST: {{ .Release.Name }}-redis-client
-  REDIS_PORT: "6379"
-  REDIS_DB: "0"
+  {{- $redis := include "librenms.redisEnabled" . }}
+  {{- if $redis }}
+  REDIS_HOST: {{ include "librenms.redisHost" . }}
+  REDIS_PORT: {{ include "librenms.redisPort" . | quote }}
+  REDIS_DB: {{ include "librenms.redisDb" . | quote }}
+  {{- end }}
+  {{- if .Values.librenms.rrdcached.enabled }}
   RRDCACHED_SERVER: "{{ .Release.Name }}-rrdcached:42217"
+  {{- end }}
+  {{- if $redis }}
   CACHE_DRIVER: redis
   SESSION_DRIVER: redis
+  {{- else }}
+  CACHE_DRIVER: file
+  SESSION_DRIVER: file
+  {{- end }}
   DB_HOST: {{ include "librenms.dbHost" . }}
   DB_PORT: {{ include "librenms.dbPort" . | quote }}
   DB_USERNAME: {{ include "librenms.dbUser" . }}

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -1090,6 +1090,27 @@
             "description": "LibreNMS ingress configuration",
             "additionalProperties": true
         },
+        "externalRedis": {
+            "type": "object",
+            "description": "External Redis configuration. Used when redis.enabled is false.",
+            "additionalProperties": false,
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Redis host (DNS name or IP address). Blank disables Redis and falls back to the file cache and session drivers."
+                },
+                "port": {
+                    "type": "integer",
+                    "description": "Redis port",
+                    "default": 6379
+                },
+                "db": {
+                    "type": "integer",
+                    "description": "Redis database number",
+                    "default": 0
+                }
+            }
+        },
         "externalDatabase": {
             "type": "object",
             "description": "External database configuration. Used when mysql.enabled is false.",

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -385,6 +385,18 @@ librenms:
     # -- Extra volume mounts for rrdcached containers
     extraVolumeMounts: []
 
+# -- External Redis configuration. Used when `redis.enabled` is false. Leave
+# `host` blank to run without Redis at all, in which case LibreNMS falls back to
+# the file cache and session drivers -- only safe for a single frontend replica,
+# since pollers and frontends no longer share cache or session state.
+externalRedis:
+  # -- Redis host (DNS name or IP address)
+  host: ""
+  # -- Redis port
+  port: 6379
+  # -- Redis database number
+  db: 0
+
 # -- LibreNMS ingress configuration
 ingress:
   # -- Enable or disable ingress


### PR DESCRIPTION
## Problem

`librenms-configmap.yml` emitted `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RRDCACHED_SERVER`, `CACHE_DRIVER: redis` and `SESSION_DRIVER: redis` unconditionally, ignoring `redis.enabled` and `librenms.rrdcached.enabled`.

Rendering with either toggle off produced a release pointing at Services that are never created:

```
$ helm template test ./charts/librenms --set redis.enabled=false --set librenms.rrdcached.enabled=false
  REDIS_HOST: test-redis-client            # no such Service
  RRDCACHED_SERVER: "test-rrdcached:42217" # no such Service
  CACHE_DRIVER: redis
  SESSION_DRIVER: redis
```

## Change

`RRDCACHED_SERVER` is emitted only when rrdcached is enabled.

Redis settings are emitted only when Redis is actually reachable. That covers two cases: the bundled subchart, or an external instance named by the new `externalRedis` block, mirroring the existing `mysql.enabled` / `externalDatabase` split. With neither, `CACHE_DRIVER` and `SESSION_DRIVER` fall back to `file`.

`externalRedis` is wider than a pure guard. Gating only on `redis.enabled` would have forced the file drivers on anyone running `redis.enabled: false` with an external Redis supplied through `extraEnvs`, silently unsharing cache and session state across pods. The block avoids trading one misconfiguration for another.

The README documents that the file drivers are only safe for a single frontend replica and not suitable for distributed polling.

## Verification

```
A) bundled redis + rrdcached (defaults)
     REDIS_HOST: test-redis-client / PORT "6379" / DB "0"
     RRDCACHED_SERVER: "test-rrdcached:42217"
     CACHE_DRIVER: redis / SESSION_DRIVER: redis

B) redis.enabled=false, no external host
     CACHE_DRIVER: file / SESSION_DRIVER: file

C) redis.enabled=false + externalRedis host/port/db
     REDIS_HOST: redis.prod.internal / PORT "6380" / DB "3"
     CACHE_DRIVER: redis / SESSION_DRIVER: redis

D) rrdcached.enabled=false
     RRDCACHED_SERVER absent
```

ConfigMap key order is unchanged, so the full rendered output under default values is byte-identical to `develop`. `librenms.configChecksum` is therefore stable and existing releases do not roll pods on upgrade.

Not covered by CI: the `externalRedis` path cannot be exercised from `ci/test-values.yaml`, which runs with the bundled Redis enabled.
