### PR TITLE
fix(serviceaccount): make serviceAccountName settable, drop dead helpers

### DIFF
--- a/charts/librenms/ci/test-values.yaml
+++ b/charts/librenms/ci/test-values.yaml
@@ -29,6 +29,8 @@ librenms:
         memory: 128Mi
         ephemeral-storage: 100Mi
   frontend:
+    # the namespace default SA always exists, so ct install can schedule the pods
+    serviceAccountName: default
     appUrl: "https://librenms.example.com"
     appTrustedProxies:
       - "10.0.0.0/8"
@@ -49,6 +51,8 @@ librenms:
         memory: 256Mi
         ephemeral-storage: 250Mi
   poller:
+    # the namespace default SA always exists, so ct install can schedule the pods
+    serviceAccountName: default
     extraEnvs:
       - name: POLLER_DEBUG
         value: "true"
@@ -101,6 +105,8 @@ librenms:
         memory: 128Mi
         ephemeral-storage: 100Mi
   rrdcached:
+    # the namespace default SA always exists, so ct install can schedule the pods
+    serviceAccountName: default
     extraEnvs:
       - name: RRD_DEBUG
         value: "true"

--- a/charts/librenms/templates/_helpers.tpl
+++ b/charts/librenms/templates/_helpers.tpl
@@ -66,17 +66,6 @@ Create the name of the pollers
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
-*/}}
-{{- define "librenms.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "librenms.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create the name of the secret to use
 */}}
 {{- define "librenms.secretName" -}}
@@ -223,25 +212,5 @@ Redis database number
 {{- print "0" -}}
 {{- else -}}
 {{- .Values.externalRedis.db | default 0 -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Validate external database configuration
-*/}}
-{{- define "librenms.validateExternalDB" -}}
-{{- if not .Values.mysql.enabled -}}
-{{- if not .Values.externalDatabase.host -}}
-{{- fail "externalDatabase.host is required when mysql.enabled is false" -}}
-{{- end -}}
-{{- if not .Values.externalDatabase.name -}}
-{{- fail "externalDatabase.name is required when mysql.enabled is false" -}}
-{{- end -}}
-{{- if not .Values.externalDatabase.user -}}
-{{- fail "externalDatabase.user is required when mysql.enabled is false" -}}
-{{- end -}}
-{{- if and (not .Values.externalDatabase.existingSecret.name) (not .Values.externalDatabase.password) -}}
-{{- fail "Either externalDatabase.existingSecret.name or externalDatabase.password must be set when mysql.enabled is false" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/librenms/templates/librenms-deployment.yml
+++ b/charts/librenms/templates/librenms-deployment.yml
@@ -22,8 +22,8 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}
         app.kubernetes.io/instance: frontend
     spec:
-      {{- with .Values.librenms.frontend }}
-      serviceAccountName: {{ .serviceAccountName }}
+      {{- with .Values.librenms.frontend.serviceAccountName }}
+      serviceAccountName: {{ . }}
       {{- end }}
       {{- with .Values.librenms.frontend.nodeSelector }}
       nodeSelector:

--- a/charts/librenms/templates/librenms-poller-ss.yml
+++ b/charts/librenms/templates/librenms-poller-ss.yml
@@ -22,8 +22,8 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- with .Values.librenms.poller }}
-      serviceAccountName: {{ .serviceAccountName }}
+      {{- with .Values.librenms.poller.serviceAccountName }}
+      serviceAccountName: {{ . }}
       {{- end }}
       {{- with .Values.librenms.poller.nodeSelector }}
       nodeSelector:

--- a/charts/librenms/templates/rrdcached-deployment.yml
+++ b/charts/librenms/templates/rrdcached-deployment.yml
@@ -21,8 +21,8 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}
         app.kubernetes.io/instance: rrdcached
     spec:
-      {{- with .Values.librenms.rrdcached }}
-      serviceAccountName: {{ .serviceAccountName }}
+      {{- with .Values.librenms.rrdcached.serviceAccountName }}
+      serviceAccountName: {{ . }}
       {{- end }}
       {{- with .Values.librenms.rrdcached.nodeSelector }}
       nodeSelector:

--- a/charts/librenms/values.schema.json
+++ b/charts/librenms/values.schema.json
@@ -267,6 +267,10 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "serviceAccountName": {
+                            "type": "string",
+                            "description": "Name of an existing ServiceAccount to run the pods under. The chart does not create ServiceAccounts."
+                        },
                         "enabled": {
                             "type": "boolean",
                             "description": "Frontend enabled",
@@ -390,6 +394,10 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "serviceAccountName": {
+                            "type": "string",
+                            "description": "Name of an existing ServiceAccount to run the pods under. The chart does not create ServiceAccounts."
+                        },
                         "name": {
                             "type": "string",
                             "description": "Poller name",
@@ -528,6 +536,10 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "serviceAccountName": {
+                            "type": "string",
+                            "description": "Name of an existing ServiceAccount to run the pods under. The chart does not create ServiceAccounts."
+                        },
                         "enabled": {
                             "type": "boolean",
                             "description": "RRDCached enabled",

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -66,6 +66,9 @@ librenms:
 
   # Frontend container configurations options
   frontend:
+    # -- Name of an existing ServiceAccount to run the pods under. The chart does
+    # not create ServiceAccounts; leave blank to use the namespace default.
+    serviceAccountName: ""
     # -- Frontend enabled
     enabled: true
     # -- Frontend replicas
@@ -123,6 +126,9 @@ librenms:
 
   # Distributed poller container configurations options
   poller:
+    # -- Name of an existing ServiceAccount to run the pods under. The chart does
+    # not create ServiceAccounts; leave blank to use the namespace default.
+    serviceAccountName: ""
     # -- Poller name
     name: ""
     # -- Poller replicas
@@ -320,6 +326,9 @@ librenms:
   # in this LibreNMS helm chart. See the rrdcached documentation for more
   # information: https://oss.oetiker.ch/rrdtool/doc/rrdcached.en.html
   rrdcached:
+    # -- Name of an existing ServiceAccount to run the pods under. The chart does
+    # not create ServiceAccounts; leave blank to use the namespace default.
+    serviceAccountName: ""
     # -- RRDCached enabled
     enabled: true
     image:


### PR DESCRIPTION
## serviceAccountName could never be set

All three workloads read `serviceAccountName` from their component values:

```yaml
{{- with .Values.librenms.frontend }}
serviceAccountName: {{ .serviceAccountName }}
{{- end }}
```

The key was absent from `values.yaml` and rejected by `values.schema.json`:

```
$ helm template ... --set librenms.frontend.serviceAccountName=librenms-sa
Error: values don't meet the specifications of the schema(s) in the following chart(s):
- at '/librenms/frontend': additional properties 'serviceAccountName' not allowed
```

So no service account could be assigned to any pod in this chart, and the field always rendered as `serviceAccountName: ` with an empty value. The `with` guarded the whole component dict, which is always truthy, rather than the field.

Added `serviceAccountName` to `values.yaml` and the schema for `frontend`, `poller` and `rrdcached`, and moved the guard onto the field so it is omitted when unset. The chart still creates no ServiceAccounts; the value names an existing one.

## Removed helpers

`librenms.serviceAccountName` read `.Values.serviceAccount.create`. There is no `serviceAccount` block in `values.yaml`, so the nil dereference made any call fail:

```
error calling include: nil pointer evaluating interface {}.create
```

`librenms.validateExternalDB` duplicated checks already enforced elsewhere. Each of its four conditions fires today from the `required` and `fail` calls in `dbHost`, `dbName`, `dbUser` and `dbPasswordEnv`, verified by blanking each field in turn.

Both were unreferenced. `librenms.labels`, `selectorLabels`, `chart`, `name` and `fullname` are also currently unreferenced but are left in place: they are the standard scaffold and are what a future fix to the label conventions would build on.

## Verification

- default render: no `serviceAccountName` emitted by this chart's templates
- with the value set on all three components: `sa-frontend`, `sa-poller`, `sa-rrdcached` each render
- `helm lint` passes
- full rendered manifest set accepted by `kubectl apply --dry-run=server` on kind, Gateway API CRDs installed

`ci/test-values.yaml` sets `serviceAccountName: default`. A non-existent ServiceAccount would leave pods unschedulable and fail `ct install`; the namespace default always exists.
