### PR TITLE
fix(ingress): stop mutating global values, refresh the annotations example

### DIFF
--- a/charts/librenms/ci/test-values.yaml
+++ b/charts/librenms/ci/test-values.yaml
@@ -128,6 +128,13 @@ librenms:
         ephemeral-storage: 500Mi
 ingress:
   enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+  tls:
+    - secretName: librenms-ci-tls
+      hosts:
+        - chart-example.local
 gateway:
   enabled: true
   annotations:

--- a/charts/librenms/templates/ingress.yml
+++ b/charts/librenms/templates/ingress.yml
@@ -1,9 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := .Release.Name  -}}
 {{- $svcPort := 8000 -}}
+{{- /*
+Work on a copy: `set` on .Values.ingress.annotations mutates the global values
+for the rest of the render, not just this template.
+*/ -}}
+{{- $annotations := deepCopy (.Values.ingress.annotations | default dict) -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set $annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -19,7 +24,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     app.kubernetes.io/instance: frontend
-  {{- with .Values.ingress.annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/librenms/values.yaml
+++ b/charts/librenms/values.yaml
@@ -412,10 +412,11 @@ ingress:
   enabled: false
   # -- Ingress class name
   className: ""
-  # -- Ingress annotations
+  # -- Ingress annotations. Use `className` above to select the controller;
+  # the `kubernetes.io/ingress.class` annotation it replaced is retired.
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # nginx.ingress.kubernetes.io/proxy-body-size: "0"
   # -- Ingress rules
   hosts:
     - host: chart-example.local


### PR DESCRIPTION
## Mutation of shared values

On clusters older than 1.18 the template injected the legacy ingress class annotation by writing straight into the values tree:

```
{{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
```

`set` mutates the map in place, so the change outlives this template and is visible to the rest of the render. Demonstrated with two probe templates that print `hasKey .Values.ingress.annotations "kubernetes.io/ingress.class"`, rendered at `--kube-version 1.17.0`:

before
```
probe: "aaa-before-ingress"   hasClassAnnotation: "true"
probe: "zzz-after-ingress"    hasClassAnnotation: "false"
```

after
```
probe: "aaa-before-ingress"   hasClassAnnotation: "false"
probe: "zzz-after-ingress"    hasClassAnnotation: "false"
```

The split reflects Helm's render order, which is reverse-sorted: `zzz` renders before `ingress.yml`, `aaa` after. Only the template that ran after the injection saw the mutated key.

Nothing in the chart reads `ingress.annotations` today, so there is no user-visible bug to fix. The annotations are now assembled on a local copy.

Rendered output is identical on all Kubernetes versions. The 1.18 and 1.19 branches are untouched; the pre-1.18 path still injects the annotation into the Ingress it emits.

## Annotations example

The commented example suggested `kubernetes.io/ingress.class: nginx`. `ingressClassName` replaced that annotation and the chart already exposes it as `ingress.className`. Replaced with current annotations, and the key's description now points at `className` for controller selection.

## CI

`ci/test-values.yaml` set only `ingress.enabled`, leaving `className`, `annotations` and `tls` uncovered. All three are now set, so the Ingress rendered under CI exercises `ingressClassName`, the annotations block and the TLS block.

## Out of scope

The `extensions/v1beta1` and `networking.k8s.io/v1beta1` branches are left in place. Removing them raises the chart's minimum Kubernetes version, which needs a `kubeVersion` constraint in Chart.yaml and a release note rather than being folded into this change.
