### PR TITLE
ci: emit conventional commit messages from automated updates

### DIFF
--- a/.github/workflows/set-appVersion.yml
+++ b/.github/workflows/set-appVersion.yml
@@ -32,3 +32,5 @@ jobs:
       
       # Commit all changed files back to the repository
       - uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "chore(appversion): sync appVersion with librenms image tag"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommitScopeDisabled"
+  ],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "packageRules": [
+    {
+      "description": "Updates under charts/ change what the chart deploys and are user-facing. CI actions and tooling stay chore.",
+      "matchFileNames": [
+        "charts/**"
+      ],
+      "semanticCommitType": "deps"
+    }
   ]
 }


### PR DESCRIPTION
Renovate ran with `semanticCommits` at its default of `auto`, which did not engage on this repository's mixed commit history. `git-auto-commit-action` in the appVersion sync workflow used its default message, `Apply automatic changes`. Neither produced a parseable commit type.

## Changes

Renovate now emits:

- `deps: <description>` for updates under `charts/`
- `chore: <description>` for CI actions and tooling

The appVersion sync commits as `chore(appversion)`.

Updates under `charts/` change what the chart deploys and are user-facing. CI action and tooling updates are not.

## Rationale

Chart releases are driven almost entirely by automated updates. Over the last eight releases, dependency bumps and appVersion syncs were the only content of six of them, and none of those commits carried a type.

`semanticCommitScope` is disabled via the `:semanticCommitScopeDisabled` preset, so prefixes are `deps:` rather than `deps(deps):`.

## Effect

None on rendered output or chart behaviour. This only changes the commit messages written by automation.
