### PR TITLE
ci: adopt release-please for versioning and changelog

### DIFF
--- a/.github/workflows/chart-testing.yml
+++ b/.github/workflows/chart-testing.yml
@@ -37,32 +37,29 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # The chart version is owned by release-please, so feature branches do not
+      # bump it. Version increments are asserted on the release pull request.
       - name: Run chart-testing (lint)
-        if: steps.list-changed.outputs.changed == 'true' && github.ref != 'refs/heads/develop'
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
 
-      - name: Run chart-testing (lint & version)
-        if: github.event.pull_request.base.ref == 'main' 
-        run: ct lint --target-branch main
-
       - name: Create kind cluster
-        if: steps.list-changed.outputs.changed == 'true' || github.event.pull_request.base.ref == 'main' 
+        if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
 
       - name: Install Gateway API CRDs
-        if: steps.list-changed.outputs.changed == 'true' || github.event.pull_request.base.ref == 'main'
+        if: steps.list-changed.outputs.changed == 'true'
         run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
 
-      - name: Run chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true' && github.ref != 'refs/heads/develop'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --skip-clean-up
-      
-      - name: Run chart-testing (install & upgrades)
-        if: github.event.pull_request.base.ref == 'main' 
-        run: ct install --target-branch main --upgrade
+      # Upgrade testing installs the chart as it exists on the target branch and
+      # upgrades to the branch under test, so it is meaningful even when the
+      # chart version is unchanged.
+      - name: Run chart-testing (install & upgrade)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --upgrade
 
       - name: Debug - Check pod status (on failure)
-        if: failure() && (steps.list-changed.outputs.changed == 'true' || github.event.pull_request.base.ref == 'main')
+        if: failure() && steps.list-changed.outputs.changed == 'true'
         run: |
           echo "=== Pod Status ==="
           kubectl get pods -A
@@ -70,7 +67,7 @@ jobs:
           kubectl get events -A --sort-by='.lastTimestamp' | tail -50
 
       - name: Debug - Pod logs (on failure)
-        if: failure() && (steps.list-changed.outputs.changed == 'true' || github.event.pull_request.base.ref == 'main')
+        if: failure() && steps.list-changed.outputs.changed == 'true'
         run: |
           echo "=== Logs from failed pods ==="
           for pod in $(kubectl get pods -A -o json | jq -r '.items[] | select(.status.containerStatuses[]?.ready == false) | "\(.metadata.namespace)/\(.metadata.name)"'); do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      pull-requests: write
 
     runs-on: ubuntu-latest
     steps:
@@ -61,3 +62,13 @@ jobs:
             fi
             helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
           done
+
+      # Runs after chart-releaser so the release it just published is visible as
+      # the starting point for the next changelog. release-please owns the chart
+      # version and CHANGELOG.md; chart-releaser owns tags and GitHub releases.
+      - name: Run release-please
+        uses: googleapis/release-please-action@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "charts/librenms": "9.2.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    "charts/librenms": {
+      "release-type": "helm",
+      "component": "librenms",
+      "include-component-in-tag": true,
+      "include-v-in-tag": false,
+      "tag-separator": "-",
+      "skip-github-release": true,
+      "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adopts release-please for chart versioning and changelog generation, and reworks chart-testing for a single-branch model.

## Ownership

- release-please owns `charts/librenms/Chart.yaml` `version` and `charts/librenms/CHANGELOG.md`.
- chart-releaser continues to own tags, GitHub releases and the chart repository index.

The release-please step runs after chart-releaser so the release just published is visible as the starting point for the next changelog. Tag configuration reproduces the existing `librenms-<version>` scheme, so release-please resolves the previous release from chart-releaser's releases. `.release-please-manifest.json` is seeded at 9.2.0.

## Verified

Dry-run against the current chart history, from `librenms-9.2.0`:

```
## [9.2.1](compare/librenms-9.2.0...librenms-9.2.1)

### Bug Fixes
* configmap: gate Redis and RRDCached settings on their toggles
* ingress: stop mutating global values, refresh the annotations example
* secret: preserve the generated APP_KEY across upgrades
* serviceaccount: make serviceAccountName settable, drop dead helpers
```

Correct patch bump, correct boundary, correct file updates.

## chart-testing

- The version increment check is removed. Feature branches no longer bump the chart version, so the check cannot pass on them.
- Upgrade testing runs on every pull request that touches a chart, rather than only on pull requests targeting `main`. chart-testing installs the chart as it exists on the target branch and upgrades to the branch under test, so this is meaningful even when the chart version is unchanged.
- Conditions on `github.ref` are removed. On `pull_request` events `github.ref` is `refs/pull/<n>/merge`, so the previous `develop` guards were always true.
- Steps key off the repository default branch rather than a hardcoded branch name, so this is correct before and after the branch model change.

## Changelog sections

`deps` maps to a Dependencies section. Renovate emits `deps:` for updates under `charts/` and `chore:` for CI and tooling, so dependency updates that change what the chart deploys are user facing and tooling updates are not.

## Required repository settings

Two changes are needed outside this pull request.

1. `merge_commit_message` must be `BLANK`. With `PR_TITLE`, the merge commit body carries the conventional PR title, and release-please splits it out as a second commit, duplicating every entry in the changelog.
2. The default branch moves to `main` and `develop` is deleted.

## Not covered by CI

This pull request changes no chart files, so `ct list-changed` finds nothing and the chart-testing steps are skipped. The reworked steps are first exercised by the next pull request that touches `charts/`.
