### PR TITLE
docs: remove duplicate 9.2.1 changelog entries

### DIFF
--- a/charts/librenms/CHANGELOG.md
+++ b/charts/librenms/CHANGELOG.md
@@ -5,11 +5,7 @@
 
 ### Bug Fixes
 
-* **configmap:** gate Redis and RRDCached settings on their toggles ([11121f8](https://github.com/librenms/helm-charts/commit/11121f873ecb05f166a529256bc376dfa719fede))
 * **configmap:** gate Redis and RRDCached settings on their toggles ([420603c](https://github.com/librenms/helm-charts/commit/420603c282ed57fa9e2f65d24f9e7df8d4d71ca4))
-* **ingress:** stop mutating global values, refresh the annotations example ([2a42127](https://github.com/librenms/helm-charts/commit/2a421275db22026c274588a68a837409fadd2ca9))
 * **ingress:** stop mutating global values, refresh the annotations example ([eca257c](https://github.com/librenms/helm-charts/commit/eca257c195da6ce5b16a60a1161731dddda4944d))
-* **secret:** preserve the generated APP_KEY across upgrades ([4560bfb](https://github.com/librenms/helm-charts/commit/4560bfbe4dd3e9c43997a04762d284c477a7993a))
 * **secret:** preserve the generated APP_KEY across upgrades ([dcaa088](https://github.com/librenms/helm-charts/commit/dcaa0885876b4aa9e70ab724d36499c185152363))
-* **serviceaccount:** make serviceAccountName settable, drop dead helpers ([50e25e7](https://github.com/librenms/helm-charts/commit/50e25e76cb2225957569bdcadba1719457605e4a))
 * **serviceaccount:** make serviceAccountName settable, drop dead helpers ([8aefe00](https://github.com/librenms/helm-charts/commit/8aefe005a4c338170c47dace429ec15bd8205791))


### PR DESCRIPTION
The 9.2.1 changelog listed each fix twice, once for the branch commit and once
for the merge commit that carried the same conventional message. The history
predates the move to squash merges, which produces one commit per pull request.

Keep the branch commit links, which point at the change itself rather than at
the merge.

The published `librenms-9.2.1.tgz` embeds the uncorrected file and is not
affected by this change.
