### PR TITLE
feat!: require Kubernetes 1.26 or newer

### DIFF
--- a/charts/librenms/Chart.yaml
+++ b/charts/librenms/Chart.yaml
@@ -4,6 +4,7 @@ description: LibreNMS is an autodiscovering PHP/MySQL-based network monitoring s
 type: application
 version: 9.2.1
 appVersion: "26.8.1"
+kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: jacobw
     url: https://github.com/jacobw

--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -12,7 +12,8 @@ $ helm install my-release librenms/librenms
 
 ## Prerequisites
 
-- This chart has only been tested on Kubernetes 1.18+, but should work on 1.14+
+- Kubernetes 1.26 or newer. The chart declares this as `kubeVersion`, so Helm refuses to
+  install on older clusters.
 - Recent versions of Helm 3 are supported
 
 ## Installing the Chart
@@ -241,6 +242,10 @@ Each entry in `paths` becomes one HTTPRoute rule backed by the frontend service 
 
 Requires the Gateway API CRDs to be installed in the cluster and a controller implementing them.
 `HTTPRoute` has been stable at `gateway.networking.k8s.io/v1` since Gateway API v1.0.
+
+The CRDs carry their own Kubernetes requirement, separate from this chart's. Gateway API
+v1.6.1 needs Kubernetes 1.31 or newer — its `standard-install.yaml` fails on 1.30 and below.
+Older Gateway API releases support older clusters.
 
 When the Gateway terminates TLS, set `librenms.frontend.appUrl` and
 `librenms.frontend.appTrustedProxies` as described under


### PR DESCRIPTION
Both subcharts declare `kubeVersion: '>=1.26.0-0'`, but Helm enforces the constraint only on the top-level chart, so the requirement had no effect. Declare it on the chart itself.

Verified on kind: the chart installs at 1.26 with `gateway.enabled: true`, and Helm now refuses 1.25 with `chart requires kubeVersion: >=1.26.0-0`.

Also removes the ingress template's pre-1.19 API fallbacks. It branched on `networking.k8s.io/v1beta1` and `extensions/v1beta1`, both removed in Kubernetes 1.22, and gated `ingressClassName` and `pathType` on 1.18. The declared floor makes every one of those branches unreachable, and the rendered output is unchanged. The `deepCopy` of the annotations existed only so the pre-1.18 `ingress.class` fallback could not mutate the global values; with the fallback gone it has no purpose.

Documentation: replaces the prerequisite claiming the chart works on Kubernetes 1.14+, and records that the Gateway API CRDs carry a Kubernetes requirement of their own — v1.6.1 needs 1.31 or newer.

BREAKING CHANGE: Helm refuses to install or upgrade the chart on Kubernetes older than 1.26.
