### PR TITLE
refactor(ingress): drop the pre-1.19 API fallbacks

### DIFF
--- a/charts/librenms/templates/ingress.yml
+++ b/charts/librenms/templates/ingress.yml
@@ -1,36 +1,20 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := .Release.Name  -}}
 {{- $svcPort := 8000 -}}
-{{- /*
-Work on a copy: `set` on .Values.ingress.annotations mutates the global values
-for the rest of the render, not just this template.
-*/ -}}
-{{- $annotations := deepCopy (.Values.ingress.annotations | default dict) -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set $annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     app.kubernetes.io/instance: frontend
-  {{- with $annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
@@ -49,19 +33,14 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+            {{- with .pathType }}
+            pathType: {{ . }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
The template branched on `networking.k8s.io/v1beta1` and `extensions/v1beta1`, both removed in Kubernetes 1.22, and gated `ingressClassName` and `pathType` on 1.18. The chart now declares `kubeVersion: ">=1.26.0-0"`, so none of those branches can be reached.

The `deepCopy` of the annotations existed only so the pre-1.18 `ingress.class` fallback could not mutate the global values. With the fallback gone it has no purpose.

Rendered output is unchanged: `helm template` against `ci/test-values.yaml` produces byte-identical output before and after, at the default Kubernetes version and at the 1.26 floor.
