### PR TITLE
feat!: follow the standard Kubernetes label conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,24 @@ Do not repeat values that already have non-empty defaults.
 reads but the schema omits cannot be set, and fails silently. Add new values to both
 files.
 
+## Labels
+
+Every resource carries the standard `app.kubernetes.io` labels. The helpers take a dict,
+not the surrounding context:
+
+```yaml
+metadata:
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "poller") | nindent 4 }}
+```
+
+Use `librenms.selectorLabels` for `spec.selector`, never `librenms.labels`. Selector labels
+are immutable on Deployments and StatefulSets, and the chart and version labels change on
+every release.
+
+Omit `component` for resources that are not part of one, such as the ConfigMaps and the
+Secret.
+
 ## Commit messages and pull requests
 
 Pull requests are squash-merged. The PR title becomes the commit subject and must be a

--- a/charts/librenms/README.md.gotmpl
+++ b/charts/librenms/README.md.gotmpl
@@ -25,6 +25,29 @@ $ helm repo add librenms https://www.librenms.org/helm-charts
 $ helm install my-release librenms/librenms
 ```
 
+## Upgrading to 10.0.0
+
+10.0.0 corrects the chart's labels. `app.kubernetes.io/name` now holds the chart name and
+`app.kubernetes.io/instance` the release name, and the component moves to
+`app.kubernetes.io/component`.
+
+`spec.selector` is immutable on Deployments and StatefulSets, so `helm upgrade` fails with
+`field is immutable`. Delete the workloads first, then upgrade. Releases before 10.0.0 put
+no labels on the workload objects themselves, so they have to be named:
+
+```shell
+$ kubectl delete deployment -n NAMESPACE --ignore-not-found \
+    RELEASE-frontend RELEASE-rrdcached RELEASE-syslogng RELEASE-snmptrapd
+$ kubectl delete statefulset -n NAMESPACE --ignore-not-found RELEASE-poller
+$ helm upgrade RELEASE librenms/librenms -n NAMESPACE
+```
+
+Set the StatefulSet name to `librenms.poller.name` instead if that value is overridden.
+
+The PersistentVolumeClaims are separate objects and are not deleted, so RRD data and the
+database survive. The frontend and pollers are unavailable between the delete and the
+upgrade.
+
 ## Database Configuration
 
 ### Internal Database (Default)

--- a/charts/librenms/templates/_helpers.tpl
+++ b/charts/librenms/templates/_helpers.tpl
@@ -35,23 +35,29 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Common labels
+Common labels. Call with a dict:
+{{- include "librenms.labels" (dict "root" . "component" "frontend") | nindent 4 }}
 */}}
 {{- define "librenms.labels" -}}
-helm.sh/chart: {{ include "librenms.chart" . }}
+helm.sh/chart: {{ include "librenms.chart" .root }}
 {{ include "librenms.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- if .root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels. These land in spec.selector.matchLabels, which is immutable on
+Deployments and StatefulSets, so nothing that changes between releases belongs
+here: no chart version, no app version.
 */}}
 {{- define "librenms.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "librenms.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "librenms.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+{{- with .component }}
+app.kubernetes.io/component: {{ . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/librenms/templates/httproute.yml
+++ b/charts/librenms/templates/httproute.yml
@@ -10,8 +10,7 @@ kind: HTTPRoute
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: frontend
+    {{- include "librenms.labels" (dict "root" . "component" "frontend") | nindent 4 }}
   {{- with .Values.gateway.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/librenms/templates/ingress.yml
+++ b/charts/librenms/templates/ingress.yml
@@ -6,8 +6,7 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: frontend
+    {{- include "librenms.labels" (dict "root" . "component" "frontend") | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/librenms/templates/librenms-configmap.yml
+++ b/charts/librenms/templates/librenms-configmap.yml
@@ -3,6 +3,8 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "") | nindent 4 }}
 data:
   TZ: {{ .Values.librenms.timezone}}
   DB_TIMEOUT: {{ include "librenms.dbTimeout" . | quote }}
@@ -37,6 +39,8 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-files
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "") | nindent 4 }}
 data:
   custom.php: |-
 {{ tpl (.Files.Get "files/custom.php") . | indent 4 }}

--- a/charts/librenms/templates/librenms-cron.yml
+++ b/charts/librenms/templates/librenms-cron.yml
@@ -3,12 +3,16 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-snmp-scanner
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "snmp-scanner") | nindent 4 }}
 spec:
   schedule: "{{.Values.librenms.snmp_scanner.cron }}"
   jobTemplate:
     spec:
       template:
         metadata:
+          labels:
+            {{- include "librenms.labels" (dict "root" . "component" "snmp-scanner") | nindent 12 }}
           annotations:
             checksum/config: {{ include "librenms.configChecksum" . }}
             {{- with .Values.librenms.snmp_scanner.podAnnotations }}

--- a/charts/librenms/templates/librenms-deployment.yml
+++ b/charts/librenms/templates/librenms-deployment.yml
@@ -3,14 +3,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-frontend
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "frontend") | nindent 4 }}
 spec:
   {{- with .Values.librenms.frontend }}
   replicas: {{ .replicas }}
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
-      app.kubernetes.io/instance: frontend
+      {{- include "librenms.selectorLabels" (dict "root" . "component" "frontend") | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -19,8 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}
-        app.kubernetes.io/instance: frontend
+        {{- include "librenms.labels" (dict "root" . "component" "frontend") | nindent 8 }}
     spec:
       {{- with .Values.librenms.frontend.serviceAccountName }}
       serviceAccountName: {{ . }}

--- a/charts/librenms/templates/librenms-poller-ss.yml
+++ b/charts/librenms/templates/librenms-poller-ss.yml
@@ -2,14 +2,15 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "librenms.poller.name" . }}
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "poller") | nindent 4 }}
 spec:
   {{- with .Values.librenms.poller }}
   replicas: {{ .replicas  | default "2" }}
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "librenms.selectorLabels" (dict "root" . "component" "poller") | nindent 6 }}
   serviceName: "poller"
   template:
     metadata:
@@ -19,8 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "librenms.labels" (dict "root" . "component" "poller") | nindent 8 }}
     spec:
       {{- with .Values.librenms.poller.serviceAccountName }}
       serviceAccountName: {{ . }}

--- a/charts/librenms/templates/librenms-secret.yml
+++ b/charts/librenms/templates/librenms-secret.yml
@@ -23,6 +23,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "") | nindent 4 }}
 type: Opaque
 stringData:
   appkey: {{ $appkey | quote }}

--- a/charts/librenms/templates/librenms-service.yml
+++ b/charts/librenms/templates/librenms-service.yml
@@ -3,10 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "frontend") | nindent 4 }}
 spec:
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: frontend
+    {{- include "librenms.selectorLabels" (dict "root" . "component" "frontend") | nindent 4 }}
   ports:
     - name: {{ .Release.Name }}
       protocol: TCP

--- a/charts/librenms/templates/librenms-snmptrapd-deployment.yml
+++ b/charts/librenms/templates/librenms-snmptrapd-deployment.yml
@@ -3,12 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-snmptrapd
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "snmptrapd") | nindent 4 }}
 spec:
   replicas: {{ .Values.librenms.snmptrapd.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
-      app.kubernetes.io/instance: snmptrapd
+      {{- include "librenms.selectorLabels" (dict "root" . "component" "snmptrapd") | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -17,8 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}
-        app.kubernetes.io/instance: snmptrapd
+        {{- include "librenms.labels" (dict "root" . "component" "snmptrapd") | nindent 8 }}
     spec:
       {{- with .Values.librenms.snmptrapd.nodeSelector }}
       nodeSelector:

--- a/charts/librenms/templates/librenms-snmptrapd-service.yml
+++ b/charts/librenms/templates/librenms-snmptrapd-service.yml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-snmptrapd
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "snmptrapd") | nindent 4 }}
   {{- with $svc.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,8 +19,7 @@ spec:
   externalTrafficPolicy: {{ . }}
   {{- end }}
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: snmptrapd
+    {{- include "librenms.selectorLabels" (dict "root" . "component" "snmptrapd") | nindent 4 }}
   ports:
     - name: snmptrap-udp
       protocol: UDP

--- a/charts/librenms/templates/librenms-syslog-deployment.yml
+++ b/charts/librenms/templates/librenms-syslog-deployment.yml
@@ -3,12 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-syslogng
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "syslogng") | nindent 4 }}
 spec:
   replicas: {{ .Values.librenms.syslogng.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
-      app.kubernetes.io/instance: syslogng
+      {{- include "librenms.selectorLabels" (dict "root" . "component" "syslogng") | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -17,8 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}
-        app.kubernetes.io/instance: syslogng
+        {{- include "librenms.labels" (dict "root" . "component" "syslogng") | nindent 8 }}
     spec:
       {{- with .Values.librenms.syslogng.nodeSelector }}
       nodeSelector:

--- a/charts/librenms/templates/librenms-syslog-service.yml
+++ b/charts/librenms/templates/librenms-syslog-service.yml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-syslogng
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "syslogng") | nindent 4 }}
   {{- with $svc.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,8 +19,7 @@ spec:
   externalTrafficPolicy: {{ . }}
   {{- end }}
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
-    app.kubernetes.io/instance: syslogng
+    {{- include "librenms.selectorLabels" (dict "root" . "component" "syslogng") | nindent 4 }}
   ports:
     - name: syslog-udp
       protocol: UDP

--- a/charts/librenms/templates/rrdcached-deployment.yml
+++ b/charts/librenms/templates/rrdcached-deployment.yml
@@ -3,14 +3,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-rrdcached
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "rrdcached") | nindent 4 }}
 spec:
   strategy: 
     type: Recreate
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
-      app.kubernetes.io/instance: rrdcached
+      {{- include "librenms.selectorLabels" (dict "root" . "component" "rrdcached") | nindent 6 }}
   template:
     metadata:
       {{- with .Values.librenms.rrdcached.podAnnotations }}
@@ -18,8 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}
-        app.kubernetes.io/instance: rrdcached
+        {{- include "librenms.labels" (dict "root" . "component" "rrdcached") | nindent 8 }}
     spec:
       {{- with .Values.librenms.rrdcached.serviceAccountName }}
       serviceAccountName: {{ . }}

--- a/charts/librenms/templates/rrdcached-pvc.yml
+++ b/charts/librenms/templates/rrdcached-pvc.yml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-rrdcached
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "rrdcached") | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -18,6 +20,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-rrdcached-journal
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "rrdcached") | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/charts/librenms/templates/rrdcached-service.yml
+++ b/charts/librenms/templates/rrdcached-service.yml
@@ -3,10 +3,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-rrdcached
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "rrdcached") | nindent 4 }}
 spec:
   selector:
-      app.kubernetes.io/name: {{ .Release.Name }}
-      app.kubernetes.io/instance: rrdcached
+    {{- include "librenms.selectorLabels" (dict "root" . "component" "rrdcached") | nindent 4 }}
   ports:
     - name: rrdcached
       protocol: TCP
@@ -17,10 +18,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-rrdcached-headless
+  labels:
+    {{- include "librenms.labels" (dict "root" . "component" "rrdcached") | nindent 4 }}
 spec:
   selector:
-      app.kubernetes.io/name: {{ .Release.Name }}
-      app.kubernetes.io/instance: rrdcached
+    {{- include "librenms.selectorLabels" (dict "root" . "component" "rrdcached") | nindent 4 }}
   ports:
     - name: rrdcached
       protocol: TCP


### PR DESCRIPTION
`app.kubernetes.io/name` held the release name and `app.kubernetes.io/instance` held the component, the reverse of the convention. `name` is now the chart name, `instance` the release name, and the component moves to `app.kubernetes.io/component`. This matches what the mysql and redis subcharts already do.

The poller StatefulSet set `instance` to the release name rather than to a component. A release named after a component — `frontend`, `rrdcached`, `syslogng`, `snmptrapd` — gave the StatefulSet and that component's Deployment identical selectors *and* identical pod labels, so each adopted the other's pods. With a release named `rrdcached`, all five selectors are now distinct.

Every resource now carries `helm.sh/chart`, `app.kubernetes.io/version` and `app.kubernetes.io/managed-by`. The ConfigMaps, Secret, PersistentVolumeClaims and CronJob previously carried no labels at all.

Verified on kind against a release installed from published 9.2.1: `helm upgrade` fails with `spec.selector: field is immutable` on all four Deployments and the StatefulSet; deleting those five objects and upgrading succeeds; all four PersistentVolumeClaims survive; and the rrdcached Service resolves to the new pod.

`ct install --upgrade` fails on this pull request for that reason. chart-testing skips the previous-to-current upgrade path only for a non-breaking SemVer change, and since release-please owns the version this branch is still 9.2.1 to 9.2.1. The failure is the breaking change being detected correctly.

README gains an "Upgrading to 10.0.0" section with the exact commands. Releases before 10.0.0 put no labels on the workload objects themselves, so the migration deletes them by name.

BREAKING CHANGE: `spec.selector` is immutable on Deployments and StatefulSets, so upgrading an existing release fails with `field is immutable`. Delete the librenms Deployments and the poller StatefulSet before upgrading. The PersistentVolumeClaims are separate objects and are not affected.
