### PR TITLE
ci: open the release pull request as a GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,13 +128,31 @@ jobs:
                 --add-label "autorelease: tagged" --remove-label "autorelease: pending"
             done
 
+      # release-please's pull request is authored by whichever identity its token
+      # belongs to. secrets.GITHUB_TOKEN authors as github-actions[bot], which holds
+      # no access to this repository, and Actions holds pull_request runs on such
+      # pull requests behind manual approval. Approving starts chart testing from
+      # cold, so the roughly eleven minutes it takes are spent at the point of merge
+      # rather than while the release pull request sits open. Runs on pull requests
+      # opened by an app installation identity start unheld.
+      #
+      # Falls back to secrets.GITHUB_TOKEN, and so to the current behaviour, when the
+      # app is not configured.
+      - name: Mint a release-please app token
+        id: release-please-token
+        if: vars.RELEASE_APP_CLIENT_ID != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       # Runs after chart-releaser so the release it just published is visible as
       # the starting point for the next changelog. release-please owns the chart
       # version and CHANGELOG.md; chart-releaser owns tags and GitHub releases.
       - name: Run release-please
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.release-please-token.outputs.token || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           # release-please otherwise targets the repository default branch,


### PR DESCRIPTION
`secrets.GITHUB_TOKEN` authors the release pull request as `github-actions[bot]`, which
holds no access to this repository:

```
gh api repos/librenms/helm-charts/collaborators/github-actions%5Bbot%5D/permission
{"permission":"none","push":false,"pull":false}
```

Actions holds `pull_request` runs on its pull requests behind manual approval, so
`Lint and Test Charts` does not start until a maintainer approves it. On #273 attempt 1
concluded `action_required` without starting, and the run that passed was attempt 2,
triggered by a maintainer, taking 11m24s. Chart testing therefore begins at the point of
merge rather than while the release pull request is open. Renovate branches are held the
same way.

Mint a GitHub App installation token and pass that to release-please in place of
`secrets.GITHUB_TOKEN`. Runs on pull requests opened by an app installation identity are
not held.

Measured on a fork. Both probes were a single non-chart file, carried no workflow change,
and were `author_association: NONE` on attempt 1:

| pull request author | conclusion | started |
| --- | --- | --- |
| `github-actions[bot]` | `action_required` | never |
| app installation bot | `success` | immediately |

`author_association` is not the discriminator: prometheus-community/helm-charts runs
`renovate[bot]`, also `CONTRIBUTOR`, ungated.

Configuration, already in place on this repository:

- `RELEASE_APP_CLIENT_ID` repository variable
- `RELEASE_APP_PRIVATE_KEY` repository secret
- the app installed on `librenms/helm-charts` with `contents: write`, `issues: write`,
  `pull_requests: write`, `metadata: read`

The step is skipped and release-please keeps `secrets.GITHUB_TOKEN` when the variable is
unset.

Only release-please's token changes. chart-releaser, the GHCR login, the release notes step
and the label step keep `secrets.GITHUB_TOKEN`.

Not addressed: `license/cla`. cla-assistant flags the pull request's committer and an app's
bot user cannot sign, so that check stays pending exactly as it does now.
