### PR TITLE
ci: pin actions to commit SHAs

### DIFF
--- a/.github/workflows/chart-testing.yml
+++ b/.github/workflows/chart-testing.yml
@@ -7,21 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5.0.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: v4.2.4
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Add repositories
         run: |
@@ -45,7 +45,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
 
       - name: Install Gateway API CRDs
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - name: Add repositories
         run: |
@@ -34,7 +34,7 @@ jobs:
           done
           
       - name: Generate and commit helm docs
-        uses: losisin/helm-docs-github-action@v2
+        uses: losisin/helm-docs-github-action@3a4528e97c49a5e83de6b78c50c61c8ee5c9f944 # v2.0.0
         with:
           chart-search-root: ./charts/librenms
           template-files: README.md.gotmpl
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run chart-releaser
         if: steps.release-check.outputs.new == 'true'
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           skip_existing: true
         env:
@@ -72,7 +72,7 @@ jobs:
       # see https://github.com/helm/chart-releaser/issues/183
       - name: Login to GitHub Container Registry
         if: steps.release-check.outputs.new == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -141,7 +141,7 @@ jobs:
       - name: Mint a release-please app token
         id: release-please-token
         if: vars.RELEASE_APP_CLIENT_ID != ''
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -150,7 +150,7 @@ jobs:
       # the starting point for the next changelog. release-please owns the chart
       # version and CHANGELOG.md; chart-releaser owns tags and GitHub releases.
       - name: Run release-please
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.release-please-token.outputs.token || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json

--- a/.github/workflows/set-appVersion.yml
+++ b/.github/workflows/set-appVersion.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
 
@@ -31,6 +31,6 @@ jobs:
 
       
       # Commit all changed files back to the repository
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "chore(appversion): sync appVersion with librenms image tag"

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":semanticCommitScopeDisabled"
+    ":semanticCommitScopeDisabled",
+    "helpers:pinGitHubActionDigests"
   ],
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",


### PR DESCRIPTION
Every `uses:` across `chart-testing.yml`, `release.yml` and `set-appVersion.yml` referenced a mutable tag. Tags can be moved, so a compromised upstream action runs here with whatever permissions the job holds. `release.yml` is the exposed one: it carries `GITHUB_TOKEN` write access, pushes to GHCR and publishes releases.

Each reference is now a full commit SHA with the resolved version in a trailing comment.

| Action | Was | Pinned to |
| --- | --- | --- |
| `actions/checkout` | `v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1 |
| `azure/setup-helm` | `v5`, `v5.0.1` | `9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310` # v5.0.1 |
| `actions/setup-python` | `v7` | `5fda3b95a4ea91299a34e894583c3862153e4b97` # v7.0.0 |
| `losisin/helm-docs-github-action` | `v2` | `3a4528e97c49a5e83de6b78c50c61c8ee5c9f944` # v2.0.0 |
| `helm/chart-releaser-action` | `v1.7.0` | `cae68fefc6b5f367a0275617c9f83181ba54714f` # v1.7.0 |
| `docker/login-action` | `v4` | `dbcb813823bdd20940b903addbd779551569679f` # v4.6.0 |
| `actions/create-github-app-token` | `v3` | `bcd2ba49218906704ab6c1aa796996da409d3eb1` # v3.2.0 |
| `googleapis/release-please-action` | `v5` | `45996ed1f6d02564a971a2fa1b5860e934307cf7` # v5.0.0 |
| `stefanzweifel/git-auto-commit-action` | `v7` | `4a55954c782fc1ea30b9056cd3e7a2b40ca8887d` # v7.2.0 |
| `helm/chart-testing-action` | `v2.8.0` | `6ec842c01de15ebb84c8627d2744a0c2f2755c9f` # v2.8.0 |
| `helm/kind-action` | `v1.14.0` | `ef37e7f390d99f746eb8b610417061a60e82a6cc` # v1.14.0 |

Each SHA is the commit the named tag pointed at. No version changes. `azure/setup-helm` was on `v5` in `release.yml` and `v5.0.1` in `chart-testing.yml`; both already resolved to the same commit, so the two references are now identical.

`renovate.json` extends `helpers:pinGitHubActionDigests`, so Renovate bumps the SHAs and pins any action added later. Workflow files fall outside `charts/**`, so those updates stay `chore` under the existing package rule.

Not covered by CI: workflow files are not linted here, and no chart files change, so `ct list-changed` finds nothing.