### PR TITLE
ci: type LibreNMS image updates as feat or fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,25 @@ For a breaking change, append `!` to the type or add a `BREAKING CHANGE:` footer
 bumps major.
 
 Scope is optional and free-form: the component or template touched, such as `ingress`,
-`configmap`, `gateway`, `frontend` or `syslogng`. Renovate sets its own type and omits
-the scope.
+`configmap`, `gateway`, `frontend` or `syslogng`. Renovate omits the scope.
+
+### Renovate types
+
+`renovate.json` maps automated updates onto those types:
+
+| Update | Type |
+| --- | --- |
+| `librenms/librenms`, major or minor | `feat` |
+| `librenms/librenms`, patch or digest | `fix` |
+| anything else under `charts/` | `deps` |
+| workflow actions and tooling | `chore` |
+
+The LibreNMS image is what the chart ships rather than a dependency of it, so it drives
+the chart version. LibreNMS is CalVer: a minor update is a new monthly release, a patch
+update is an upstream hotfix.
+
+An upstream release that breaks existing installs needs the pull request title changed by
+hand to `feat!` with a `BREAKING CHANGE:` footer.
 
 ## Chart version
 

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,34 @@
         "charts/**"
       ],
       "semanticCommitType": "deps"
+    },
+    {
+      "description": "The LibreNMS image is what the chart ships, not a dependency of it. A new release train is a feature.",
+      "matchFileNames": [
+        "charts/**"
+      ],
+      "matchDepNames": [
+        "librenms/librenms"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "semanticCommitType": "feat"
+    },
+    {
+      "description": "An upstream LibreNMS hotfix is a fix.",
+      "matchFileNames": [
+        "charts/**"
+      ],
+      "matchDepNames": [
+        "librenms/librenms"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "digest"
+      ],
+      "semanticCommitType": "fix"
     }
   ]
 }


### PR DESCRIPTION
The LibreNMS image is what the chart ships, not a dependency of it. Renovate sent every
update under `charts/` to `deps`, so an upstream release landed in the Dependencies
section of the changelog next to the busybox init image and cut a patch chart version.

LibreNMS is CalVer, so the update type maps onto the release train:

| Update | Type |
| --- | --- |
| `librenms/librenms`, major or minor | `feat` |
| `librenms/librenms`, patch or digest | `fix` |
| anything else under `charts/` | `deps` |
| workflow actions and tooling | `chore` |

A new monthly release now cuts a chart minor under Features; an upstream hotfix cuts a
patch under Bug Fixes. Every other dependency under `charts/` is unchanged.

An upstream release that breaks existing installs still needs the pull request title
changed by hand to `feat!` with a `BREAKING CHANGE:` footer.

`CONTRIBUTING.md` records the mapping alongside the existing type table.
